### PR TITLE
add in a fetch for the client spec in the gh workflow

### DIFF
--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -51,8 +51,12 @@ jobs:
           category: clippy
           wait-for-processing: true
       - name: Get client spec
-        run: |
-          git clone --depth 5 --branch v4.2.2 https://github.com/Unleash/client-specification.git client-specification
+        use: actions/checkout@v3
+        with:
+          repository: Unleash/client-specification
+          branch: v4.2.2
+          path: client-specification
+          fetch-depth: 5
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -51,7 +51,7 @@ jobs:
           category: clippy
           wait-for-processing: true
       - name: Get client spec
-        use: actions/checkout@v3
+        uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
           branch: v4.2.2

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -50,6 +50,9 @@ jobs:
           sarif_file: rust-clippy-results.sarif
           category: clippy
           wait-for-processing: true
+      - name: Get client spec
+        run: |
+          git clone --depth 5 --branch v4.2.2 https://github.com/Unleash/client-specification.git client-specification
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -56,7 +56,6 @@ jobs:
           repository: Unleash/client-specification
           branch: v4.2.2
           path: client-specification
-          fetch-depth: 5
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          branch: v4.2.2
+          ref: v4.2.2
           path: client-specification
       - name: Run tests
         run: |


### PR DESCRIPTION
There might be a much better way of doing this. I'm open to suggestions. But ultimately, we need to resolve the client spec before we run tests