### PR TITLE
ci: update workflow to use rust-cache

### DIFF
--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -22,22 +22,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: ⚡ Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.rustup
-            target
-          key: debug-${{ runner.os }}-stable
-          restore-keys: |
-            debug-${{ runner.os }}-
       - name: Install rust
         run: |
-          rustup install stable
-          rustup default stable
+          rustup set auto-self-update disable
+          rustup toolchain install stable --profile default
           rustup show
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Install required cargo packages for reporting format
         run: cargo install clippy-sarif sarif-fmt
       - name: Run rust-clippy


### PR DESCRIPTION
We've struggled with buildtimes for our rust-actions. After finding the rust-cache action it seems like we've managed to cache enough of the target folder that we no longer have to build all our dependencies each time we make changes to our own code.

This PR switches this project's workflow to use rust-cache as well