### PR TITLE
chore: add basic benchmarks

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -28,3 +28,8 @@ version = "1.0"
 test-case = "2.2.2"
 async-std = "1.0.1"
 async-std-test = "0.0.4"
+criterion = "0.4.0"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/unleash-yggdrasil/benches/benchmark.rs
+++ b/unleash-yggdrasil/benches/benchmark.rs
@@ -1,0 +1,175 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use unleash_types::client_features::{
+    ClientFeature, ClientFeatures, Constraint, Operator, Strategy,
+};
+use unleash_yggdrasil::{Context, EngineState};
+
+fn is_enabled(engine: &EngineState, toggle_name: String, context: &Context) {
+    engine.is_enabled(toggle_name, context);
+}
+
+fn benchmark_with_no_strategy(c: &mut Criterion) {
+    let mut engine = EngineState::default();
+    engine.take_state(ClientFeatures {
+        version: 2,
+        features: vec![ClientFeature {
+            name: "test".into(),
+            enabled: true,
+            ..ClientFeature::default()
+        }],
+        segments: None,
+        query: None,
+    });
+    let context = Context {
+        user_id: None,
+        session_id: None,
+        environment: None,
+        app_name: None,
+        current_time: None,
+        remote_address: None,
+        properties: None,
+    };
+    c.bench_function("basic evaluation with no strategies", |b| {
+        b.iter(|| is_enabled(&engine, black_box("test".to_string()), black_box(&context)))
+    });
+}
+
+fn benchmark_with_single_constraint(c: &mut Criterion) {
+    let mut engine = EngineState::default();
+    engine.take_state(ClientFeatures {
+        version: 2,
+        features: vec![ClientFeature {
+            name: "test".into(),
+            enabled: true,
+            strategies: Some(vec![Strategy {
+                name: "default".into(),
+                segments: None,
+                constraints: Some(vec![Constraint {
+                    context_name: "userId".into(),
+                    operator: Operator::In,
+                    case_insensitive: false,
+                    inverted: false,
+                    values: Some(vec!["7".into()]),
+                    value: None,
+                }]),
+                parameters: None,
+                sort_order: None,
+            }]),
+            ..ClientFeature::default()
+        }],
+        segments: None,
+        query: None,
+    });
+    let context = Context {
+        user_id: Some("7".into()),
+        session_id: None,
+        environment: None,
+        app_name: None,
+        current_time: None,
+        remote_address: None,
+        properties: None,
+    };
+    c.bench_function("basic evaluation with one strategy", |b| {
+        b.iter(|| is_enabled(&engine, black_box("test".to_string()), black_box(&context)))
+    });
+}
+
+fn benchmark_with_two_constraints(c: &mut Criterion) {
+    let mut engine = EngineState::default();
+    engine.take_state(ClientFeatures {
+        version: 2,
+        features: vec![ClientFeature {
+            name: "test".into(),
+            enabled: true,
+            strategies: Some(vec![Strategy {
+                name: "default".into(),
+                segments: None,
+                constraints: Some(vec![
+                    Constraint {
+                        context_name: "userId".into(),
+                        operator: Operator::In,
+                        case_insensitive: false,
+                        inverted: false,
+                        values: Some(vec!["7".into()]),
+                        value: None,
+                    },
+                    Constraint {
+                        context_name: "userId".into(),
+                        operator: Operator::NotIn,
+                        case_insensitive: false,
+                        inverted: false,
+                        values: Some(vec!["8".into()]),
+                        value: None,
+                    },
+                ]),
+                parameters: None,
+                sort_order: None,
+            }]),
+            ..ClientFeature::default()
+        }],
+        segments: None,
+        query: None,
+    });
+    let context = Context {
+        user_id: Some("7".into()),
+        session_id: None,
+        environment: None,
+        app_name: None,
+        current_time: None,
+        remote_address: None,
+        properties: None,
+    };
+    c.bench_function("basic evaluation with two strategies", |b| {
+        b.iter(|| is_enabled(&engine, black_box("test".to_string()), black_box(&context)))
+    });
+}
+
+fn benchmark_engine_ingestion(c: &mut Criterion) {
+    let mut engine = EngineState::default();
+    let state = ClientFeatures {
+        version: 2,
+        features: vec![ClientFeature {
+            name: "test".into(),
+            enabled: true,
+            strategies: Some(vec![Strategy {
+                name: "default".into(),
+                segments: None,
+                constraints: Some(vec![
+                    Constraint {
+                        context_name: "userId".into(),
+                        operator: Operator::In,
+                        case_insensitive: false,
+                        inverted: false,
+                        values: Some(vec!["7".into()]),
+                        value: None,
+                    },
+                    Constraint {
+                        context_name: "userId".into(),
+                        operator: Operator::NotIn,
+                        case_insensitive: false,
+                        inverted: false,
+                        values: Some(vec!["8".into()]),
+                        value: None,
+                    },
+                ]),
+                parameters: None,
+                sort_order: None,
+            }]),
+            ..ClientFeature::default()
+        }],
+        segments: None,
+        query: None,
+    };
+    c.bench_function("engine ingestion", |b| {
+        b.iter(|| engine.take_state(black_box(state.clone())))
+    });
+}
+
+criterion_group!(
+    benches,
+    benchmark_with_no_strategy,
+    benchmark_with_single_constraint,
+    benchmark_with_two_constraints,
+    benchmark_engine_ingestion
+);
+criterion_main!(benches);

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -17,8 +17,8 @@ use serde::{de, Deserialize, Serialize};
 use state::EnrichedContext;
 use strategy_parsing::{compile_rule, normalized_hash, RuleFragment};
 use strategy_upgrade::upgrade;
-use unleash_types::client_features::{ClientFeatures, Payload, Segment, Variant};
 pub use unleash_types::client_features::Context;
+use unleash_types::client_features::{ClientFeatures, Payload, Segment, Variant};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
@@ -79,17 +79,12 @@ impl<'de> de::Deserialize<'de> for IPAddress {
     }
 }
 
+#[derive(Default)]
 pub struct EngineState {
     compiled_state: Option<CompiledState>,
 }
 
 impl EngineState {
-    pub fn default() -> EngineState {
-        EngineState {
-            compiled_state: None,
-        }
-    }
-
     fn get_toggle(&self, name: String) -> Option<&CompiledToggle> {
         match &self.compiled_state {
             Some(state) => state.get(&name),


### PR DESCRIPTION
Adds basic benchmarks for a sniff test for performance. This isn't a complete analysis of the performance profile, only a rough guide