### PR TITLE
fix: upgrade user id strategy to string types rather than numerics

### DIFF
--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -689,6 +689,8 @@ mod tests {
     #[test_case("user_id in [1, 3, 6]", true)]
     #[test_case("user_id in [1, 3, 5]", false)]
     #[test_case("user_id not_in [1, 3, 5]", true)]
+    #[test_case("user_id in [\"dfsfsd\"]", false)]
+    #[test_case("user_id not_in [\"dfsfsd\"]", true)]
     fn run_numeric_list_test(rule: &str, expected: bool) {
         let rule = compile_rule(rule).expect("");
         let context = context_from_user_id("6");

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -101,7 +101,7 @@ fn upgrade_user_id_strategy(strategy: &Strategy) -> String {
     match strategy.get_param("userIds") {
         Some(user_ids) => {
             let user_ids = user_ids
-                .split(",")
+                .split(',')
                 .map(|id| format!("\"{}\"", id.trim()))
                 .collect::<Vec<String>>()
                 .join(",");

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -99,7 +99,14 @@ fn upgrade_flexible_rollout_strategy(strategy: &Strategy) -> String {
 
 fn upgrade_user_id_strategy(strategy: &Strategy) -> String {
     match strategy.get_param("userIds") {
-        Some(user_ids) => format!("user_id in [{}]", user_ids),
+        Some(user_ids) => {
+            let user_ids = user_ids
+                .split(",")
+                .map(|id| format!("\"{}\"", id.trim()))
+                .collect::<Vec<String>>()
+                .join(",");
+            format!("user_id in [{}]", user_ids)
+        }
         None => "".into(),
     }
 }
@@ -291,7 +298,7 @@ mod tests {
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
-        assert_eq!(output, "user_id in [123, 222, 88]".to_string())
+        assert_eq!(output, "user_id in [\"123\",\"222\",\"88\"]".to_string())
     }
 
     #[test]
@@ -308,7 +315,7 @@ mod tests {
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
-        assert_eq!(output, "user_id in [123, 222, 88]".to_string())
+        assert_eq!(output, "user_id in [\"123\",\"222\",\"88\"]".to_string())
     }
 
     #[test]


### PR DESCRIPTION
User ids can be string types, prior to this, Yggdrasil was trying to upgrade these to numeric rules like so:

`user_in IN [1,2,3]`

This doesn't work when the user supplies a user id which doesn't parse as a numeric. This PR changes this so that the strategy is upgraded to a string type like so:

`user_in IN ["1","2","3"]`
