### PR TITLE
feat: implement metrics gathering for core

### DIFF
--- a/python-sdk/src/lib.rs
+++ b/python-sdk/src/lib.rs
@@ -94,7 +94,7 @@ impl UnleashEngine {
 
     pub fn take_state(&mut self, state: String) {
         let toggles = serde_json::from_str(&state).expect("Failed to parse client spec");
-        self.engine_state.take_state(toggles)
+        self.engine_state.take_state(toggles);
     }
 
     pub fn is_enabled(&self, name: String, context: &Context) -> bool {

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.0"
 lazy_static = "1.4.0"
 semver = "1.0.5"
 convert_case = "0.6.0"
-unleash-types = "0.8.2"
+unleash-types = {path="../../unleash-types"}
 chrono = "0.4.23"
 
 [dependencies.serde]

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.0"
 lazy_static = "1.4.0"
 semver = "1.0.5"
 convert_case = "0.6.0"
-unleash-types = {path="../../unleash-types"}
+unleash-types = "0.8.3"
 chrono = "0.4.23"
 
 [dependencies.serde]


### PR DESCRIPTION
This adds metrics gathering for the core Yggdrasil client, using atomic primitives behind the scenes, which means this is should still be Send & Sync (yay!). The tradeoff here is that the client won't hold metrics longer than the engine holds the internal state - when passing in a new state for compilation, the engine will return unhandled metrics, that's now the callers responsibility to handle unsent metrics