### PR TITLE
task: Bump unleash types to 0.10.0

### DIFF
--- a/java-sdk/java-glue/Cargo.toml
+++ b/java-sdk/java-glue/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 jni = "0.19.0"
 unleash-yggdrasil = {path = "../../unleash-yggdrasil"}
 serde_json = "1.0.68"
-unleash-types = "0.9.0"
+unleash-types = "0.10.0"
 
 [lib]
 crate_type = ["cdylib"]

--- a/node-sdk/Cargo.toml
+++ b/node-sdk/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-unleash-types = "0.9.0"
+unleash-types = "0.10.0"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}
 serde-wasm-bindgen = "0.4.5"
 wasm-bindgen = "0.2.83"

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -12,7 +12,7 @@ name = "python_sdk"
 pyo3 = {version = "0.17.1", features = ["extension-module"]}
 serde_json = "1.0.68"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}
-unleash-types = "0.9.0"
+unleash-types = "0.10.0"
 
 [dependencies.serde]
 features = ["derive"]

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.0"
 lazy_static = "1.4.0"
 semver = "1.0.5"
 convert_case = "0.6.0"
-unleash-types = "0.9.0"
+unleash-types = "0.10.0"
 chrono = "0.4.23"
 
 [dependencies.serde]


### PR DESCRIPTION
Having updated unleash types to 0.10.0 to handle properties as an object map when using it as a query parameter we need yggdrasil to be on the same version.