### PR TITLE
fix: fix variant stickiness

### DIFF
--- a/unleash-yggdrasil/src/error.rs
+++ b/unleash-yggdrasil/src/error.rs
@@ -1,3 +1,0 @@
-pub enum YggdrasilError {
-    StickinessExpectedButNotFound,
-}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->

I noticed that `.get_variant()` doesn't work properly - the logic behind stickiness didn't consider `default` as a potential value (which I believe is present for every variant by "default"?). This caused `.resolve_variant()` to return `None`, which resulted in the default disabled variant being returned for the `.get_variant()` calls. 

While trying to fix that I refactored the variant stickiness logic to match the behavior of other SDKs (e.g. node, go) - unless that was intentional? :thinking:

Also fallback random stickiness was using `[0, 100)` range and the total variants weight sums up to 1000, so I believe for it to work properly it should be `[0, total_weight)` instead, right?

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
