### PR TITLE
fix: redesigns the way stickiness is handled in the grammar to support default and random

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -274,7 +274,7 @@ impl EngineState {
 
         let target = get_seed(stickiness, context)
             .map(|seed| normalized_hash(&toggle.name, &seed, total_weight).unwrap())
-            .unwrap_or_else(|| rand::thread_rng().gen_range(0..total_weight) as u32);
+            .unwrap_or_else(|| rand::thread_rng().gen_range(0..total_weight));
 
         let mut total_weight = 0;
         for variant in variants {

--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -81,10 +81,8 @@ constraint = {
     numeric_constraint = { context_value ~ ordinal_operation ~ num }
     semver_constraint = { context_value ~ ordinal_operation ~ semver }
     rollout_constraint = { percentage ~ stickiness_param? ~ group_id_param?}
-        stickiness_param = { "sticky on " ~ stickiness_option ~ ( NULL_COALESCE ~ stickiness_option)* }
+        stickiness_param = { "sticky on " ~ context_value ~ ( NULL_COALESCE ~ context_value)* }
         group_id_param = { "with group_id of" ~ string }
-
-stickiness_option = { context_value ~ ( NULL_COALESCE ~ context_value)* }
 
 context_value = { random | user_id | session_id | remote_address | app_name | environment | current_time | property }
     user_id         = { "user_id" }

--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -29,7 +29,9 @@ string_list = { "[" ~ string ~ ( "," ~ string )* ~ "]" }
 semver_list = { "[" ~ semver ~ ( "," ~ semver )* ~ "]" }
 
 WHITESPACE = _{ " " | "\t" }
+NULL_COALESCE = _{ "|" }
 
+random = { "random" }
 
 boolean_operation = _{ and | or }
     and     = { "and" }
@@ -79,17 +81,18 @@ constraint = {
     numeric_constraint = { context_value ~ ordinal_operation ~ num }
     semver_constraint = { context_value ~ ordinal_operation ~ semver }
     rollout_constraint = { percentage ~ stickiness_param? ~ group_id_param?}
-        stickiness_param = { "sticky on " ~ context_value }
+        stickiness_param = { "sticky on " ~ stickiness_option ~ ( NULL_COALESCE ~ stickiness_option)* }
         group_id_param = { "with group_id of" ~ string }
 
-context_value = { user_id | session_id | remote_address | app_name | environment | current_time | property | random }
+stickiness_option = { context_value ~ ( NULL_COALESCE ~ context_value)* }
+
+context_value = { random | user_id | session_id | remote_address | app_name | environment | current_time | property }
     user_id         = { "user_id" }
     session_id      = { "session_id" }
     remote_address  = { "remote_address" }
     app_name        = { "app_name" }
     current_time    = { "current_time" }
     environment     = { "environment" }
-    random          = { "random()" }
     property        = { "context[" ~ string ~ "]" }
 
 

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -98,17 +98,17 @@ fn context_value(mut node: Pairs<Rule>) -> ContextResolver {
     }
 }
 
-pub(crate) fn coalesce_context_property(mut node: Pairs<Rule>) -> ContextResolver {
+pub(crate) fn coalesce_context_property(node: Pairs<Rule>) -> ContextResolver {
     let mut stickiness_resolvers = vec![];
 
-    while let Some(child) = node.next() {
+    for child in node {
         stickiness_resolvers.push(context_value(child.into_inner()))
     }
 
     Box::new(move |context: &Context| {
         stickiness_resolvers
             .iter()
-            .find_map(|resolver| resolver(&context))
+            .find_map(|resolver| resolver(context))
     })
 }
 

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -100,9 +100,8 @@ fn context_value(mut node: Pairs<Rule>) -> ContextResolver {
 
 pub(crate) fn coalesce_context_property(mut node: Pairs<Rule>) -> ContextResolver {
     let mut stickiness_resolvers = vec![];
-    let mut context_resolvers = node.next().unwrap().into_inner();
 
-    while let Some(child) = context_resolvers.next() {
+    while let Some(child) = node.next() {
         stickiness_resolvers.push(context_value(child.into_inner()))
     }
 


### PR DESCRIPTION
## What

This completely reworks the way that the `default` and `random` keywords are handled by the grammar so they work correctly and remove a bunch of ugly edge cases in the `rollout_constraint`. As a side effect, this allows us to specify much more flexible rules for stickiness.

## Why

Firstly because `random` was completely ignored in the strategy upgrade path and that needed to be fixed. This caused the strategy to instead try to use a custom context field called "random" as its stickiness property, which short circuited the entire strategy to false. 

However, the bulk of the changes here are to fix the approach that led to the broken code in the first place. This was caused by incorrectly treating the stickiness property as if it were a special case of a context property. That doesn't model a stickiness property correctly, since they're more like a context property unless they're one of two keys words - "default" or "random". I've taken a very different approach here for each keyword:

"random - This has been handled in the strategy upgrade path correctly now. It's treated as a special case when resolving a context property in the same way that the built in context properties like "userId" and "sessionId" are.  

"default" - This is now expressed as a new type in the grammar as  chain of null coalescing context properties, which models how stickiness works correctly without edge case handling. This removes a lot of brittle code when actually executing the strategy