### PR TITLE
fix: support for arbitrary strings

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -29,6 +29,7 @@ test-case = "2.2.2"
 async-std = "1.0.1"
 async-std-test = "0.0.4"
 criterion = "0.4.0"
+proptest = "1.2.0"
 
 [[bench]]
 name = "benchmark"

--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -3,9 +3,7 @@ num = @{ int ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ int)? }
 
 percentage = { ("100" | (ASCII_DIGIT ~ ASCII_DIGIT?)) ~ "%" }
 
-string = @{ "\"" ~ ( unicode_characters | punctuation_characters )* ~ "\"" }
-    unicode_characters = { LETTER | MARK | NUMBER | SYMBOL | SEPARATOR | DASH_PUNCTUATION }
-    punctuation_characters = { "." | "&" | "/" | "_" | "@" | "!" }
+string = @{ "\"" ~ ( !("\\\"" | "\"") ~ ANY | "\\" ~ "\"")* ~ "\"" }
 
 semver = @{ ASCII_DIGIT+ ~ "."  ~ ASCII_DIGIT+ ~ "."  ~ ASCII_DIGIT+ ~ semver_patch? ~ semver_build? }
     semver_patch    = @{ "-" ~ semver_fragment }

--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -5,7 +5,7 @@ percentage = { ("100" | (ASCII_DIGIT ~ ASCII_DIGIT?)) ~ "%" }
 
 string = @{ "\"" ~ ( unicode_characters | punctuation_characters )* ~ "\"" }
     unicode_characters = { LETTER | MARK | NUMBER | SYMBOL | SEPARATOR | DASH_PUNCTUATION }
-    punctuation_characters = { "." | "&" | "/" | "_" | "@" }
+    punctuation_characters = { "." | "&" | "/" | "_" | "@" | "!" }
 
 semver = @{ ASCII_DIGIT+ ~ "."  ~ ASCII_DIGIT+ ~ "."  ~ ASCII_DIGIT+ ~ semver_patch? ~ semver_build? }
     semver_patch    = @{ "-" ~ semver_fragment }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -798,4 +798,10 @@ mod tests {
         let rule = compile_rule(rule_text).unwrap();
         assert_eq!(rule(&context), true);
     }
+
+    #[test]
+    fn escaping_strings_works() {
+        let rule = "user_id in [\"Nobody likes \\\"scare quotes\\\"\"]";
+        compile_rule(rule).unwrap();
+    }
 }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -714,6 +714,7 @@ mod tests {
     #[test_case("app_name not_in [\"おはようございます\"]" ; "Japanese characters")]
     #[test_case("app_name not_in [\"😃💁\"]"; "Teenager characters" )]
     #[test_case("app_name not_in [\".&-/\"]"; "Limited punctuation characters" )]
+    #[test_case("app_name not_in [\"Exclamation marks are cool!\"]"; "Exclamation marks" )]
     fn arbitrary_unicode_is_handled(input: &str) {
         let rule_text = input;
         let rule = compile_rule(rule_text).unwrap();

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -572,9 +572,7 @@ mod tests {
         let output = upgrade(&vec![strategy], &HashMap::new());
         assert_eq!(
             output.as_str(),
-            format!(
-                "55% sticky on random with group_id of \"Feature.flexibleRollout.userId.55\""
-            )
+            format!("55% sticky on random with group_id of \"Feature.flexibleRollout.userId.55\"")
         );
     }
 

--- a/unleash-yggdrasil/tests/grammar_prop_tests.proptest-regressions
+++ b/unleash-yggdrasil/tests/grammar_prop_tests.proptest-regressions
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 0c65ec1f0e1cf006c4cedd5549e3304ed08c7f0a96bc4e71af6b20ba6c70177f # shrinks to nums = []
+cc 4958d19ae6c199c24ee0836415a12c48988de14f1e967373d92ec174b8e9ca0e # shrinks to input = "\\"

--- a/unleash-yggdrasil/tests/grammar_prop_tests.proptest-regressions
+++ b/unleash-yggdrasil/tests/grammar_prop_tests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 0c65ec1f0e1cf006c4cedd5549e3304ed08c7f0a96bc4e71af6b20ba6c70177f # shrinks to nums = []

--- a/unleash-yggdrasil/tests/grammar_prop_tests.rs
+++ b/unleash-yggdrasil/tests/grammar_prop_tests.rs
@@ -1,0 +1,14 @@
+use proptest::prelude::*;
+use unleash_yggdrasil::strategy_parsing::compile_rule;
+
+proptest! {
+    #[test]
+    fn test_compile_rule(input in "\\PC*") {
+        if !input.contains(r#""#) {
+            let rule = format!("user_id in [\"{input}\"]");
+            println!("rule: {:?}", rule);
+            let result = compile_rule(&rule);
+            prop_assert!(result.is_ok());
+        }
+    }
+}

--- a/unleash-yggdrasil/tests/grammar_prop_tests.rs
+++ b/unleash-yggdrasil/tests/grammar_prop_tests.rs
@@ -3,12 +3,10 @@ use unleash_yggdrasil::strategy_parsing::compile_rule;
 
 proptest! {
     #[test]
-    fn test_compile_rule(input in "\\PC*") {
-        if !input.contains(r#""#) {
-            let rule = format!("user_id in [\"{input}\"]");
-            println!("rule: {:?}", rule);
-            let result = compile_rule(&rule);
-            prop_assert!(result.is_ok());
-        }
+    fn test_compile_rule(input in any::<String>().prop_filter("Exclude strings with \\\", \", \\ and empty strings", |s| !s.is_empty() && !s.contains("\\\"") && !s.contains("\"") && !s.contains("\\"))) {
+        let rule = format!("user_id in [\"{}\"]", input);
+        println!("rule: {:?}", rule);
+        let result = compile_rule(&rule);
+        prop_assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
Adds support for arbitrary strings in the grammar by allowing atom escaping of quotation marks within the string rule. For bonus points, we also include escaping of those characters.