### PR TITLE
chore: updated to new chrono and unleash-types

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -8,27 +8,27 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.68"
-murmur3 = "0.5.1"
-ipnet = "2.3.1"
-rand = "0.8.4"
+serde_json = "1.0.99"
+murmur3 = "0.5.2"
+ipnet = "2.8.0"
+rand = "0.8.5"
 pest = "2.0"
 pest_derive = "2.0"
 lazy_static = "1.4.0"
-semver = "1.0.5"
+semver = "1.0.17"
 convert_case = "0.6.0"
-unleash-types = "0.10.0"
-chrono = "0.4.23"
+unleash-types = "0.10"
+chrono = "0.4.26"
 
 [dependencies.serde]
 features = ["derive"]
 version = "1.0"
 
 [dev-dependencies]
-test-case = "2.2.2"
+test-case = "3.1.0"
 async-std = "1.0.1"
 async-std-test = "0.0.4"
-criterion = "0.4.0"
+criterion = "0.5.1"
 proptest = "1.2.0"
 
 [[bench]]


### PR DESCRIPTION
### What
Bump to include update to unleash-types to avoid serializing nulls