### PR TITLE
feat: add support for strategy variants

### DIFF
--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v4.2.2
+          ref: v4.3.1
           path: client-specification
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy enough - run `cargo build` from the root of the project. You'll need an up 
 
 To run the client specs, you'll first need to clone them:
 
-`git clone --depth 5 --branch v4.2.2 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v4.3.1 https://github.com/Unleash/client-specification.git client-specification`
 
 ## Node
 

--- a/node-sdk/Cargo.toml
+++ b/node-sdk/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-unleash-types = "0.10.0"
+unleash-types = "0.10.4"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}
 serde-wasm-bindgen = "0.4.5"
 wasm-bindgen = "0.2.83"

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.0"
 lazy_static = "1.4.0"
 semver = "1.0.17"
 convert_case = "0.6.0"
-unleash-types = "0.10"
+unleash-types = "0.10.4"
 chrono = "0.4.26"
 
 [dependencies.serde]

--- a/unleash-yggdrasil/benches/benchmark.rs
+++ b/unleash-yggdrasil/benches/benchmark.rs
@@ -44,6 +44,7 @@ fn benchmark_with_single_constraint(c: &mut Criterion) {
             strategies: Some(vec![Strategy {
                 name: "default".into(),
                 segments: None,
+                variants: None,
                 constraints: Some(vec![Constraint {
                     context_name: "userId".into(),
                     operator: Operator::In,
@@ -102,6 +103,7 @@ fn benchmark_with_two_constraints(c: &mut Criterion) {
                         value: None,
                     },
                 ]),
+                variants: None,
                 parameters: None,
                 sort_order: None,
             }]),
@@ -154,6 +156,7 @@ fn benchmark_engine_ingestion(c: &mut Criterion) {
                 ]),
                 parameters: None,
                 sort_order: None,
+                variants: None,
             }]),
             ..ClientFeature::default()
         }],

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -979,45 +979,6 @@ mod test {
     }
 
     #[test]
-    pub fn strategy_variants_fallback_to_disabled_variant() {
-        let mut compiled_state = HashMap::new();
-        compiled_state.insert(
-            "some-toggle".to_string(),
-            CompiledToggle {
-                name: "some-toggle".into(),
-                enabled: true,
-                compiled_strategy: Box::new(|_| true),
-                variants: vec![CompiledVariant {
-                    name: "should-be-ignored".into(),
-                    weight: 100,
-                    stickiness: None,
-                    payload: None,
-                    overrides: None,
-                    count: AtomicU32::new(0),
-                }],
-                compiled_variant_strategy: Some(vec![(
-                    Box::new(|_| true),
-                    vec![CompiledVariant {
-                        count: AtomicU32::new(0),
-                        name: "don't-ignore-me".into(),
-                        weight: 100,
-                        stickiness: None,
-                        payload: None,
-                        overrides: None,
-                    }],
-                )]),
-                ..CompiledToggle::default()
-            },
-        );
-        let state = EngineState {
-            compiled_state: Some(compiled_state),
-            ..Default::default()
-        };
-        let variant = state.get_variant("some-toggle", &Context::default());
-        assert_eq!(variant.name, "don't-ignore-me".to_string());
-    }
-
-    #[test]
     fn strategy_variants_respect_toggles_being_disabled() {
         let mut compiled_state = HashMap::new();
         compiled_state.insert(

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -17,19 +17,22 @@ use serde::{de, Deserialize, Serialize};
 use state::EnrichedContext;
 use std::sync::atomic::Ordering;
 use strategy_parsing::{compile_rule, normalized_hash, RuleFragment};
-use strategy_upgrade::upgrade;
+use strategy_upgrade::{build_variant_rules, upgrade};
 pub use unleash_types::client_features::Context;
-use unleash_types::client_features::{ClientFeatures, Override, Payload, Segment, Variant};
+use unleash_types::client_features::{
+    ClientFeature, ClientFeatures, Override, Payload, Segment, Variant,
+};
 use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
-pub const SUPPORTED_SPEC_VERSION: &str = "4.2.2";
+pub const SUPPORTED_SPEC_VERSION: &str = "4.3.1";
 
 pub struct CompiledToggle {
     pub name: String,
     pub enabled: bool,
     pub compiled_strategy: RuleFragment,
+    pub compiled_variant_strategy: Option<Vec<(RuleFragment, Vec<CompiledVariant>)>>,
     pub variants: Vec<CompiledVariant>,
     pub yes: AtomicU32,
     pub no: AtomicU32,
@@ -54,6 +57,7 @@ impl Default for CompiledToggle {
             name: Default::default(),
             enabled: Default::default(),
             compiled_strategy: Box::new(|_| true),
+            compiled_variant_strategy: None,
             variants: Default::default(),
             yes: Default::default(),
             no: Default::default(),
@@ -89,16 +93,49 @@ fn build_segment_map(segments: &Option<Vec<Segment>>) -> HashMap<i32, Segment> {
         .unwrap_or_default()
 }
 
+fn compile_variant_rule(
+    toggle: &ClientFeature,
+    segment_map: &HashMap<i32, Segment>,
+) -> Option<Vec<(RuleFragment, Vec<CompiledVariant>)>> {
+    let variant_rules: Option<Vec<(RuleFragment, Vec<CompiledVariant>)>> =
+        build_variant_rules(&toggle.strategies.clone().unwrap_or_default(), segment_map)
+            .iter()
+            .map(|(rule_string, strategy_variants, stickiness)| {
+                let compiled_rule: Option<RuleFragment> = compile_rule(rule_string).ok();
+                compiled_rule.map(|rule| {
+                    (
+                        rule,
+                        strategy_variants
+                            .iter()
+                            .map(|strategy_variant| CompiledVariant {
+                                name: strategy_variant.name.clone(),
+                                weight: strategy_variant.weight,
+                                stickiness: Some(stickiness.clone()),
+                                payload: strategy_variant.payload.clone(),
+                                overrides: None,
+                                count: AtomicU32::new(0),
+                            })
+                            .collect(),
+                    )
+                })
+            })
+            .collect();
+
+    variant_rules
+}
+
 pub fn compile_state(state: &ClientFeatures) -> HashMap<String, CompiledToggle> {
     let mut compiled_state = HashMap::new();
     let segment_map = build_segment_map(&state.segments);
     for toggle in &state.features {
         let rule = upgrade(&toggle.strategies.clone().unwrap_or_default(), &segment_map);
+        let variant_rule = compile_variant_rule(toggle, &segment_map);
         compiled_state.insert(
             toggle.name.clone(),
             CompiledToggle {
                 name: toggle.name.clone(),
                 enabled: toggle.enabled,
+                compiled_variant_strategy: variant_rule,
                 variants: compile_variants(&toggle.variants),
                 compiled_strategy: compile_rule(rule.as_str()).unwrap(),
                 yes: AtomicU32::new(0),
@@ -302,7 +339,27 @@ impl EngineState {
 
         toggle
             .map(|toggle| {
-                let variant = self.resolve_variant(toggle, &toggle.variants, context);
+                let strategy_variants =
+                    toggle
+                        .compiled_variant_strategy
+                        .as_ref()
+                        .and_then(|variant_strategies| {
+                            let context =
+                                EnrichedContext::from(context.clone(), toggle.name.clone());
+
+                            let resolved_strategy_variants: Option<&Vec<CompiledVariant>> =
+                                variant_strategies.iter().find_map(|(rule, rule_variants)| {
+                                    (rule)(&context).then_some(rule_variants)
+                                });
+                            resolved_strategy_variants
+                        });
+
+                let variant = if let Some(strategy_variants) = strategy_variants {
+                    self.resolve_variant(toggle, strategy_variants, context)
+                } else {
+                    self.resolve_variant(toggle, &toggle.variants, context)
+                };
+
                 let enabled = self.enabled(toggle, context);
 
                 if !enabled {
@@ -470,6 +527,7 @@ mod test {
     #[test_case("13-constraint-operators.json"; "Advanced constraints")]
     #[test_case("14-constraint-semver-operators.json"; "Semver constraints")]
     #[test_case("15-global-constraints.json"; "Segments")]
+    #[test_case("16-strategy-variants.json"; "Strategy variants")]
     fn run_client_spec(spec_name: &str) {
         let spec = load_spec(spec_name);
         let mut engine = EngineState::default();
@@ -529,7 +587,7 @@ mod test {
         };
         let context = Context::default();
 
-        state.get_variant("cool-animals".into(), &context);
+        state.get_variant("cool-animals", &context);
     }
 
     #[test]
@@ -551,10 +609,7 @@ mod test {
         };
         let context = Context::default();
 
-        assert_eq!(
-            state.get_variant("test".into(), &context),
-            VariantDef::default()
-        );
+        assert_eq!(state.get_variant("test", &context), VariantDef::default());
     }
 
     #[test]
@@ -582,11 +637,11 @@ mod test {
 
         let blank_context = Context::default();
 
-        state.is_enabled("some-toggle".into(), &context_with_user_id_of_7);
-        state.is_enabled("some-toggle".into(), &context_with_user_id_of_7);
+        state.is_enabled("some-toggle", &context_with_user_id_of_7);
+        state.is_enabled("some-toggle", &context_with_user_id_of_7);
 
         //No user id, no enabled state, this should increment the "no" metric
-        state.is_enabled("some-toggle".into(), &blank_context);
+        state.is_enabled("some-toggle", &blank_context);
 
         let metrics = state.get_metrics().unwrap();
         assert_eq!(metrics.toggles.get("some-toggle").unwrap().yes, 2);
@@ -625,8 +680,8 @@ mod test {
             ..Context::default()
         };
 
-        state.get_variant("some-toggle".into(), &blank_context);
-        state.get_variant("some-toggle".into(), &context_with_user_id_of_7);
+        state.get_variant("some-toggle", &blank_context);
+        state.get_variant("some-toggle", &context_with_user_id_of_7);
 
         let metrics = state.get_metrics().unwrap();
         let toggle_metric = metrics.toggles.get("some-toggle").unwrap();
@@ -674,7 +729,7 @@ mod test {
 
         let blank_context = Context::default();
 
-        state.is_enabled("some-toggle".into(), &blank_context);
+        state.is_enabled("some-toggle", &blank_context);
 
         let metrics = state
             .take_state(ClientFeatures {
@@ -808,9 +863,9 @@ mod test {
 
         let blank_context = Context::default();
         let toggle = state.resolve("some-toggle", &blank_context).unwrap();
-        let resolved_variant = toggle.variant.name.clone();
+        let resolved_variant = toggle.variant.name;
 
-        assert_eq!(toggle.enabled, true);
+        assert!(toggle.enabled);
         assert_eq!(resolved_variant, "test-variant".to_string());
     }
 
@@ -882,5 +937,115 @@ mod test {
                 context
             }
         }
+    }
+
+    #[test]
+    pub fn strategy_variants_are_selected_over_base_variants_if_present() {
+        let mut compiled_state = HashMap::new();
+        compiled_state.insert(
+            "some-toggle".to_string(),
+            CompiledToggle {
+                name: "some-toggle".into(),
+                enabled: true,
+                compiled_strategy: Box::new(|_| true),
+                variants: vec![CompiledVariant {
+                    name: "should-be-ignored".into(),
+                    weight: 100,
+                    stickiness: None,
+                    payload: None,
+                    overrides: None,
+                    count: AtomicU32::new(0),
+                }],
+                compiled_variant_strategy: Some(vec![(
+                    Box::new(|_| true),
+                    vec![CompiledVariant {
+                        count: AtomicU32::new(0),
+                        name: "don't-ignore-me".into(),
+                        weight: 100,
+                        stickiness: None,
+                        payload: None,
+                        overrides: None,
+                    }],
+                )]),
+                ..CompiledToggle::default()
+            },
+        );
+        let state = EngineState {
+            compiled_state: Some(compiled_state),
+            ..Default::default()
+        };
+        let variant = state.get_variant("some-toggle", &Context::default());
+        assert_eq!(variant.name, "don't-ignore-me".to_string());
+    }
+
+    #[test]
+    pub fn strategy_variants_fallback_to_disabled_variant() {
+        let mut compiled_state = HashMap::new();
+        compiled_state.insert(
+            "some-toggle".to_string(),
+            CompiledToggle {
+                name: "some-toggle".into(),
+                enabled: true,
+                compiled_strategy: Box::new(|_| true),
+                variants: vec![CompiledVariant {
+                    name: "should-be-ignored".into(),
+                    weight: 100,
+                    stickiness: None,
+                    payload: None,
+                    overrides: None,
+                    count: AtomicU32::new(0),
+                }],
+                compiled_variant_strategy: Some(vec![(
+                    Box::new(|_| true),
+                    vec![CompiledVariant {
+                        count: AtomicU32::new(0),
+                        name: "don't-ignore-me".into(),
+                        weight: 100,
+                        stickiness: None,
+                        payload: None,
+                        overrides: None,
+                    }],
+                )]),
+                ..CompiledToggle::default()
+            },
+        );
+        let state = EngineState {
+            compiled_state: Some(compiled_state),
+            ..Default::default()
+        };
+        let variant = state.get_variant("some-toggle", &Context::default());
+        assert_eq!(variant.name, "don't-ignore-me".to_string());
+    }
+
+    #[test]
+    fn strategy_variants_respect_toggles_being_disabled() {
+        let mut compiled_state = HashMap::new();
+        compiled_state.insert(
+            "some-toggle".to_string(),
+            CompiledToggle {
+                name: "some-toggle".into(),
+                enabled: false,
+                compiled_strategy: Box::new(|_| true),
+                variants: vec![],
+                compiled_variant_strategy: Some(vec![(
+                    Box::new(|_| true),
+                    vec![CompiledVariant {
+                        count: AtomicU32::new(0),
+                        name: "".into(),
+                        weight: 100,
+                        stickiness: None,
+                        payload: None,
+                        overrides: None,
+                    }],
+                )]),
+                ..CompiledToggle::default()
+            },
+        );
+        let state = EngineState {
+            compiled_state: Some(compiled_state),
+            ..Default::default()
+        };
+        let variant = state.get_variant("some-toggle", &Context::default());
+        assert_eq!(variant.name, "disabled".to_string());
     }
 }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -486,6 +486,7 @@ mod tests {
     // This needs the toggle name for it to actually be useful for the parsing engine so it makes no sense
     // to have a default implementation exposed in the library but it does make testing a lot easier for this
     // test module
+    #[allow(clippy::derivable_impls)]
     impl Default for Context {
         fn default() -> Self {
             Self {
@@ -793,8 +794,10 @@ mod tests {
 
     #[test]
     fn date_constraint_respects_timezones() {
-        let mut context = Context::default();
-        context.app_name = Some("2022-01-22T11:30:00.000Z".into());
+        let context = Context {
+            app_name: Some("2022-01-22T11:30:00.000Z".into()),
+            ..Context::default()
+        };
 
         let rule_text =
             "app_name > 2022-01-22T13:00:00.000+02:00 and app_name < 2022-01-22T14:00:00.000+02:00";
@@ -804,8 +807,10 @@ mod tests {
 
     #[test]
     fn inversion_works_on_string_any_rules() {
-        let mut context = Context::default();
-        context.app_name = Some("email".into());
+        let context = Context {
+            app_name: Some("email".into()),
+            ..Context::default()
+        };
 
         let rule_text = "!app_name contains_any [\"@another.com\"]";
         let rule = compile_rule(rule_text).unwrap();

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -592,7 +592,7 @@ mod tests {
         let rule = compile_rule(rule).expect("");
         let context = Context::default();
 
-        assert_eq!(rule(&context), true);
+        assert!(rule(&context));
     }
 
     #[test_case("true", true)]
@@ -705,7 +705,7 @@ mod tests {
 
         let context = Context::default();
 
-        assert_eq!(rule(&context), true);
+        assert!(rule(&context));
     }
 
     //This needs to be swapped out for an arbitrary string test
@@ -719,7 +719,7 @@ mod tests {
         let rule_text = input;
         let rule = compile_rule(rule_text).unwrap();
 
-        assert_eq!(rule(&Context::default()), true);
+        assert!(rule(&Context::default()));
     }
 
     #[test]
@@ -727,7 +727,7 @@ mod tests {
         let rule_text = "app_name not_in []";
         let rule = compile_rule(rule_text).unwrap();
 
-        assert_eq!(rule(&Context::default()), true);
+        assert!(rule(&Context::default()));
     }
 
     #[test_case("user_id starts_with_any [\"some\"]", true)]
@@ -771,7 +771,7 @@ mod tests {
         props.insert("cutoff".into(), "2022-01-25T13:00:00.000Z".into());
         context.properties = Some(props);
 
-        assert_eq!(rule(&context), false);
+        assert!(!rule(&context));
     }
 
     #[test_case("!user_id > 8", false)]
@@ -788,7 +788,7 @@ mod tests {
         let rule_text = "100% sticky on context[\"customField\"] with group_id of \"Feature.flexible.rollout.custom.stickiness_100\"";
         let rule = compile_rule(rule_text).unwrap();
 
-        assert_eq!(rule(&Context::default()), false);
+        assert!(!rule(&Context::default()));
     }
 
     #[test]
@@ -799,7 +799,7 @@ mod tests {
         let rule_text =
             "app_name > 2022-01-22T13:00:00.000+02:00 and app_name < 2022-01-22T14:00:00.000+02:00";
         let rule = compile_rule(rule_text).unwrap();
-        assert_eq!(rule(&context), true);
+        assert!(rule(&context));
     }
 
     #[test]
@@ -809,7 +809,7 @@ mod tests {
 
         let rule_text = "!app_name contains_any [\"@another.com\"]";
         let rule = compile_rule(rule_text).unwrap();
-        assert_eq!(rule(&context), true);
+        assert!(rule(&context));
     }
 
     #[test]

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -29,7 +29,12 @@ pub fn build_variant_rules(
             (
                 upgrade_strategy(strategy, segment_map),
                 strategy.variants.clone().unwrap(),
-                "default".to_string(),
+                strategy
+                    .parameters
+                    .as_ref()
+                    .and_then(|params| params.get("stickiness"))
+                    .cloned()
+                    .unwrap_or_else(|| "default".to_string()),
             )
         })
         .collect::<Vec<(String, Vec<StrategyVariant>, String)>>()

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use unleash_types::client_features::{Constraint, Operator, Segment, Strategy};
+use unleash_types::client_features::{Constraint, Operator, Segment, Strategy, StrategyVariant};
 
 use crate::state::SdkError;
 
@@ -16,6 +16,23 @@ pub fn upgrade(strategies: &Vec<Strategy>, segment_map: &HashMap<i32, Segment>) 
         .collect::<Vec<String>>()
         .join(" or ");
     rule_text
+}
+
+pub fn build_variant_rules(
+    strategies: &[Strategy],
+    segment_map: &HashMap<i32, Segment>,
+) -> Vec<(String, Vec<StrategyVariant>, String)> {
+    strategies
+        .iter()
+        .filter(|strategy| strategy.variants.is_some())
+        .map(|strategy| {
+            (
+                upgrade_strategy(strategy, segment_map),
+                strategy.variants.clone().unwrap(),
+                "default".to_string(),
+            )
+        })
+        .collect::<Vec<(String, Vec<StrategyVariant>, String)>>()
 }
 
 trait PropResolver {
@@ -302,6 +319,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -319,6 +337,7 @@ mod tests {
             constraints: Some(vec![]),
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -342,6 +361,7 @@ mod tests {
             constraints: Some(vec![constraint]),
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -365,6 +385,7 @@ mod tests {
             constraints: Some(vec![constraint.clone(), constraint]),
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -382,6 +403,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new());
@@ -405,6 +427,7 @@ mod tests {
             constraints: Some(vec![constraint.clone(), constraint]),
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new());
@@ -434,6 +457,7 @@ mod tests {
             constraints: Some(vec![constraint]),
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -457,6 +481,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -479,6 +504,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -498,6 +524,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -519,6 +546,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -542,6 +570,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());
@@ -567,6 +596,7 @@ mod tests {
             constraints: None,
             segments: None,
             sort_order: Some(1),
+            variants: None,
         };
 
         let output = upgrade(&vec![strategy], &HashMap::new());

--- a/unleash-yggdrasil/tests/grammar_prop_tests.rs
+++ b/unleash-yggdrasil/tests/grammar_prop_tests.rs
@@ -3,7 +3,7 @@ use unleash_yggdrasil::strategy_parsing::compile_rule;
 
 proptest! {
     #[test]
-    fn test_compile_rule(input in any::<String>().prop_filter("Exclude strings with \\\", \", \\ and empty strings", |s| !s.is_empty() && !s.contains("\\\"") && !s.contains("\"") && !s.contains("\\"))) {
+    fn test_compile_rule(input in any::<String>().prop_filter("Exclude strings with \\\", \", \\ and empty strings", |s| !s.is_empty() && !s.contains("\\\"") && !s.contains('\"') && !s.contains('\\'))) {
         let rule = format!("user_id in [\"{}\"]", input);
         println!("rule: {:?}", rule);
         let result = compile_rule(&rule);

--- a/yggdrasilffi/Cargo.toml
+++ b/yggdrasilffi/Cargo.toml
@@ -13,5 +13,5 @@ name = "yggdrasilffi"
 [dependencies]
 libc = "0.2"
 serde_json = "1.0.68"
-unleash-types = "0.10.0"
+unleash-types = "0.10.4"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}


### PR DESCRIPTION
This adds support for strategy variants, as defined here:  https://github.com/Unleash/client-specification/blob/main/specifications/16-strategy-variants.json 

Metrics will not work against the strategy variants but they're not in use anywhere right now

This works a little differently from how this is likely going to be implemented in other SDKs, since it taps into the Yggdrasil grammar. The flow works like this:

- Compile the strategy to a Vec of Yggdrasil rule fragments, granular to the strategy level
- When a variant is requested, find the first strategy that resolves to true and get the strategy variants for that, reuse the strategy stickiness for that variant stickiness
- If the above is Some and not None, then pass that variant set to the standard variant resolution flow
- Else check for a standard variant

Please excuse the noise, Clippy woke up and chose violence this morning