### PR TITLE
chore: restructure ffi layer

### DIFF
--- a/ruby-engine/README.md
+++ b/ruby-engine/README.md
@@ -2,17 +2,11 @@
 
 ## Running the tests
 
-First make sure that have built the native FFI code. That can be done with Cargo anywhere in this project:
+First make sure that you have built the native FFI code and it's located in the right place. This can be done with the build script in `build.sh`:
 
 
 ```bash
-cargo build --release
-```
-
-You'll also need to set the path to the Yggdrasil native library like so:
-
-```bash
-export YGGDRASIL_LIB_PATH=/home/{YOUR_NAME_HERE}/dev/yggdrasil/target/release
+./build.sh
 ```
 
 Then you can run the tests with:


### PR DESCRIPTION
This patches the FFI protocol to always return a full and complete JSON response to the caller. This is only handled in Ruby right now so we can spike on the protocol