### PR TITLE
fix: resolves the memory leaks in the ruby ffi layer

### DIFF
--- a/ruby-engine/Gemfile
+++ b/ruby-engine/Gemfile
@@ -6,4 +6,6 @@ source "https://rubygems.org"
 
 gem "ffi"
 gem "fiddle"
-gem "get_process_mem", "~> 0.2.7"
+group :development do
+  gem "get_process_mem", "~> 0.2.7"
+end

--- a/ruby-engine/Gemfile
+++ b/ruby-engine/Gemfile
@@ -6,3 +6,4 @@ source "https://rubygems.org"
 
 gem "ffi"
 gem "fiddle"
+gem "get_process_mem", "~> 0.2.7"

--- a/ruby-engine/Gemfile.lock
+++ b/ruby-engine/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.15.5)
+    ffi (1.16.3)
     fiddle (1.1.1)
     get_process_mem (0.2.7)
       ffi (~> 1.0)

--- a/ruby-engine/Gemfile.lock
+++ b/ruby-engine/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     ffi (1.15.5)
     fiddle (1.1.1)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
 
 PLATFORMS
   x86_64-linux
@@ -10,6 +12,7 @@ PLATFORMS
 DEPENDENCIES
   ffi
   fiddle
+  get_process_mem (~> 0.2.7)
 
 BUNDLED WITH
    2.4.13

--- a/ruby-engine/README.md
+++ b/ruby-engine/README.md
@@ -15,13 +15,18 @@ Then you can run the tests with:
 rspec
 ```
 
+There's also a `mem_check.rb` in the scripts folder. This is not a bullet proof test, but it can be helpful for detecting large leaks. This requires human interaction - you need to read the output and understand what it's telling you, so it's not run as part of the test suite.
+
+```bash
+ruby scripts/mem_check.rb
+```
+
 ## Build
 
 You can build the gem with:
 
 ```bash
 gem build unleash-engine.gemspec
-
 ```
 
 Then you can install the gem for local development with:

--- a/ruby-engine/lib/unleash_engine.rb
+++ b/ruby-engine/lib/unleash_engine.rb
@@ -39,7 +39,7 @@ class UnleashEngine
   attach_function :engine_new, [], :pointer
   attach_function :engine_free, [:pointer], :void
 
-  attach_function :engine_take_state, %i[pointer string], :string, :pointer
+  attach_function :engine_take_state, %i[pointer string], :pointer
   attach_function :engine_check_enabled, %i[pointer string string], :pointer
   attach_function :engine_check_variant, %i[pointer string string], :pointer
   attach_function :engine_get_metrics, [:pointer], :pointer
@@ -58,7 +58,9 @@ class UnleashEngine
   end
 
   def take_state(toggles)
-    repsonse_ptr = UnleashEngine.engine_take_state(@engine_state, toggles)
+    response_ptr = UnleashEngine.engine_take_state(@engine_state, toggles)
+    take_toggles_response = JSON.parse(response_ptr.read_string, symbolize_names: true)
+    UnleashEngine.engine_free_response_message(response_ptr)
   end
 
   def get_variant(name, context)
@@ -97,6 +99,7 @@ class UnleashEngine
   def get_metrics
     metrics_ptr = UnleashEngine.engine_get_metrics(@engine_state)
     metrics = JSON.parse(metrics_ptr.read_string, symbolize_names: true)
+    UnleashEngine.engine_free_response_message(metrics_ptr)
     metrics[:value]
   end
 end

--- a/ruby-engine/scripts/mem_check.rb
+++ b/ruby-engine/scripts/mem_check.rb
@@ -1,0 +1,51 @@
+require 'objspace'
+require 'json'
+require_relative '../lib/unleash_engine'
+require 'get_process_mem'
+
+unleash_engine = UnleashEngine.new
+
+def run_memory_check(lambda, method_name_being_tested)
+    puts "#{method_name_being_tested} Warming up"
+
+    ## This should give us a warmup baseline to allow the runtime to assgin whatever it needs
+    for i in 0..1000000
+        lambda.call
+    end
+    GC.start
+
+    ## Now we poke the memory - only memory we need for this call should be assigned now
+    ## everything else should be done in the previous warm up
+    pre_check_memory = GetProcessMem.new.mb
+    for i in 0..1000000
+        lambda.call
+    end
+
+    GC.start
+    post_check_memory = GetProcessMem.new.mb
+
+    puts "#{method_name_being_tested} Memory diff during enabled check: #{post_check_memory} #{pre_check_memory} MB"
+    diff = post_check_memory - pre_check_memory
+    if diff < 0.5
+        puts "#{method_name_being_tested} Memory diff is within half a MB, this is an expected range"
+    else
+        STDERR.puts "WARNING: LIKELY MEMORY LEAK DETECTED. THIS REQUIRES HUMAN ATTENTION"
+        STDERR.puts "#{method_name_being_tested} Memory diff is not within the expected half MB range, this likely indicates a leak within the engine"
+    end
+
+    puts "---"
+end
+
+suite_path = File.join('../client-specification/specifications', '01-simple-examples.json')
+suite_data = JSON.parse(File.read(suite_path))
+json_client_features = suite_data['state'].to_json
+
+is_enabled = lambda { unleash_engine.enabled?('Feature.A', {}) }
+get_variant = lambda { unleash_engine.get_variant('Feature.A', {}) }
+get_metrics = lambda { unleash_engine.get_metrics() }
+take_state = lambda { unleash_engine.take_state(json_client_features) }
+
+run_memory_check(is_enabled, "IsEnabled:")
+run_memory_check(get_variant, "GetVariant:")
+run_memory_check(get_metrics, "GetMetrics:")
+run_memory_check(take_state, "TakeState:")


### PR DESCRIPTION
This fixes the remaining memory leaks in Ruby, where we previously weren't freeing resources we explicitly needed to free. This also adds a script to the ruby engine folder that will exercise the engine with a large number of allocations and do some bare bones checks for obvious leaks 

Co-authored-by: nuno@getunleash.ai