### PR TITLE
refactor: Yggdrasil FFI layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@
 /go-engine/unleash_engine.h
 /php-engine/unleash_engine.h
 /php-engine/libyggdrasilffi.so
-/ruby-engine/lib/libyggdrasilffi.so
+/ruby-engine/lib/libyggdrasilffi.*

--- a/ruby-engine/Gemfile.lock
+++ b/ruby-engine/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       ffi (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/ruby-engine/lib/unleash_engine.rb
+++ b/ruby-engine/lib/unleash_engine.rb
@@ -89,11 +89,13 @@ class UnleashEngine
   end
 
   def count_toggle(toggle_name, enabled)
-    UnleashEngine.count_toggle(@engine, toggle_name, enabled)
+    response_ptr = UnleashEngine.count_toggle(@engine, toggle_name, enabled)
+    UnleashEngine.free_response(response_ptr)
   end
 
   def count_variant(toggle_name, variant_name)
-    UnleashEngine.count_variant(@engine, toggle_name, variant_name)
+    response_ptr = UnleashEngine.count_variant(@engine, toggle_name, variant_name)
+    UnleashEngine.free_response(response_ptr)
   end
 
   def get_metrics

--- a/ruby-engine/unleash-engine.gemspec
+++ b/ruby-engine/unleash-engine.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
     s.name        = 'unleash-engine'
     s.version     = '0.0.1'
     s.date        = '2023-06-28'
-    s.summary     = 'Unleash engine for evaulating feature toggles'
+    s.summary     = 'Unleash engine for evaluating feature toggles'
     s.description = '...'
     s.authors     = ['Your Name']
     s.email       = 'you@example.com'

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use libc::c_void;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use unleash_types::{client_features::ClientFeatures, client_metrics::MetricBucket};
 use unleash_yggdrasil::{Context, EngineState, VariantDef};
 
@@ -13,6 +13,13 @@ struct Response<T> {
     status_code: ResponseCode,
     value: Option<T>,
     error_message: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
+enum ResponseCode {
+    Error = -2,
+    NotFound = -1,
+    Ok = 1,
 }
 
 impl<T> From<Result<Option<T>, FFIError>> for Response<T> {
@@ -56,257 +63,242 @@ impl From<serde_json::Error> for FFIError {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn engine_new() -> *mut c_void {
-    let state = EngineState::default();
-    Box::into_raw(Box::new(state)) as *mut c_void
+fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState, FFIError> {
+    if engine_ptr.is_null() {
+        Err(FFIError::NullError("Null engine pointer".into()))
+    } else {
+        Ok(unsafe { &mut *(engine_ptr as *mut EngineState) })
+    }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
-enum ResponseCode {
-    Error = -2,
-    NotFound = -1,
-    Ok = 1,
+fn get_str<'a>(ptr: *const c_char) -> Result<&'a str, FFIError> {
+    if ptr.is_null() {
+        Err(FFIError::NullError("Null pointer".into()))
+    } else {
+        unsafe { CStr::from_ptr(ptr).to_str().map_err(FFIError::from) }
+    }
 }
 
-/// Frees the memory allocated for the engine
+fn get_json<T: DeserializeOwned>(json_ptr: *const c_char) -> Result<T, FFIError> {
+    let json_str = get_str(json_ptr)?;
+    serde_json::from_str(json_str).map_err(FFIError::from)
+}
+
+fn result_to_json_ptr<T: Serialize>(result: Result<Option<T>, FFIError>) -> *mut c_char {
+    let response: Response<T> = result.into();
+    let json_string = serde_json::to_string(&response).unwrap();
+    CString::new(json_string).unwrap().into_raw()
+}
+
+/// Instantiates a new engine. Returns a pointer to the engine.
+///
 /// # Safety
 ///
-/// The caller is responsible for ensuring the pointer to the engine is a valid pointer,
-/// a passed null pointer is a no-op but an invalid pointer is undefined behavior.
-/// This function must be called correctly to deallocate the memory allocated for the engine in
-/// the engine_new function, failure to do so will result in a leak.
+/// The caller is responsible for freeing the allocated memory. This can be done by calling
+/// `free_engine` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_free(ptr: *mut c_void) {
-    if ptr.is_null() {
+pub extern "C" fn new_engine() -> *mut c_void {
+    let engine = EngineState::default();
+    Box::into_raw(Box::new(engine)) as *mut c_void
+}
+
+/// Frees the memory allocated for the engine.
+///
+/// # Safety
+///
+/// The caller is responsible for ensuring the argument is a valid pointer.
+/// Null pointers will result in a no-op, but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
+///
+/// This function must be called correctly in order to deallocate the memory allocated for the engine in
+/// the `new_engine` function. Failure to do so will result in a leak.
+#[no_mangle]
+pub extern "C" fn free_engine(engine_ptr: *mut c_void) {
+    if engine_ptr.is_null() {
         return;
     }
     unsafe {
-        drop(Box::from_raw(ptr as *mut EngineState));
+        drop(Box::from_raw(engine_ptr));
     }
 }
 
-/// Takes a JSON string representing a set of toggles and returns a JSON string representing
-/// the metrics that should be sent to the server
+/// Takes a JSON string representing a set of toggles. Returns a JSON string representing
+/// the metrics that should be sent to the server.
+///
 /// # Safety
 ///
-/// The caller is responsible for ensuring the pointer to the engine is a valid pointer
-/// and that the engine is not dropped while the pointer is still in use.
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
 #[no_mangle]
-pub unsafe extern "C" fn engine_take_state(ptr: *mut c_void, json: *const c_char) -> *const c_char {
-    let response: Response<()> = take_state(ptr, json).into();
-    let json = serde_json::to_string(&response).unwrap();
-    CString::new(json).unwrap().into_raw()
+pub extern "C" fn take_state(engine_ptr: *mut c_void, json_ptr: *const c_char) -> *const c_char {
+    let result: Result<Option<()>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggles: ClientFeatures = get_json(json_ptr)?;
+
+        Ok(Some(engine.take_state(toggles)))
+    })();
+
+    result_to_json_ptr(result)
 }
 
-unsafe fn take_state(ptr: *mut c_void, json: *const c_char) -> Result<Option<()>, FFIError> {
-    let engine = if !ptr.is_null() {
-        &mut *(ptr as *mut EngineState)
-    } else {
-        return Err(FFIError::NullError("Null engine pointer".into()));
-    };
-
-    let toggles: ClientFeatures = if !json.is_null() {
-        let json = CStr::from_ptr(json).to_str()?;
-        serde_json::from_str(json)?
-    } else {
-        return Err(FFIError::NullError("Null json pointer".into()));
-    };
-
-    engine.take_state(toggles);
-    Ok(Some(()))
-}
-
-/// Checks if a toggle is enabled for a given context, this function will always return a JSON encoded response of type `EnabledResponse`
+/// Checks if a toggle is enabled for a given context. Returns a JSON encoded response of type `EnabledResponse`.
+///
 /// # Safety
-/// The first argument to this function must be a valid pointer to an EngineState struct. A null pointer will
-/// result in an error message being returned to the caller, but an invalid pointer will result in undefined behavior.
-/// This pointer should not be dropped for the lifetime of this function call.
 ///
-/// The toggle_name and context parameters should be valid C Strings and not mutated for the lifetime of the function call,
-/// null pointers for these values will result in an error message being returned to the caller.
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
 ///
-/// The caller is responsible for freeing the memory allocated for the returned string, this can be done by calling
-/// engine_free_response_message on the pointer returned by this method. Failure to do so will result in a leak.
+/// The caller is responsible for freeing the allocated memory. This can be done by calling
+/// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_check_enabled(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
-    context: *const c_char,
+pub extern "C" fn check_enabled(
+    engine_ptr: *mut c_void,
+    toggle_name_ptr: *const c_char,
+    context_ptr: *const c_char,
 ) -> *const c_char {
-    let enabled_state: Response<bool> = check_enabled(ptr, toggle_name, context).into();
-    let json = serde_json::to_string(&enabled_state).unwrap();
-    CString::new(json).unwrap().into_raw()
+    let result: Result<Option<bool>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggle_name = get_str(toggle_name_ptr)?;
+        let context: Context = get_json(context_ptr)?;
+
+        Ok(engine.check_enabled(toggle_name, &context))
+    })();
+
+    result_to_json_ptr(result)
 }
 
-unsafe fn check_enabled(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
-    context: *const c_char,
-) -> Result<Option<bool>, FFIError> {
-    let engine = if !ptr.is_null() {
-        &mut *(ptr as *mut EngineState)
-    } else {
-        return Err(FFIError::NullError("Null engine pointer".into()));
-    };
-
-    let toggle_name = if !toggle_name.is_null() {
-        CStr::from_ptr(toggle_name).to_str()?
-    } else {
-        return Err(FFIError::NullError("Null toggle name pointer".into()));
-    };
-
-    let context: Context = if !context.is_null() {
-        let context_str = CStr::from_ptr(context).to_str()?;
-        serde_json::from_str(context_str)?
-    } else {
-        return Err(FFIError::NullError("Null context pointer".into()));
-    };
-
-    Ok(engine.check_enabled(toggle_name, &context))
-}
-
-/// Calculates the variant for a toggle, this function will always return a JSON encoded response of type `VariantResponse`
+/// Checks the toggle variant for a given context. Returns a JSON encoded response of type `VariantResponse`.
+///
 /// # Safety
-/// The first argument to this function must be a valid pointer to an EngineState struct. A null pointer will
-/// result in an error message being returned to the caller, but an invalid pointer will result in undefined behavior.
-/// This pointer should not be dropped for the lifetime of this function call.
 ///
-/// The toggle_name and context parameters should be valid C Strings and not mutated for the lifetime of the function call,
-/// null pointers for these values will result in an error message being returned to the caller.
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
 ///
-/// The caller is responsible for freeing the memory allocated for the returned string, this can be done by calling
-/// engine_free_response_message on the pointer returned by this method. Failure to do so will result in a leak.
+/// The caller is responsible for freeing the allocated memory. This can be done by calling
+/// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_check_variant(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
-    context: *const c_char,
+pub extern "C" fn check_variant(
+    engine_ptr: *mut c_void,
+    toggle_name_ptr: *const c_char,
+    context_ptr: *const c_char,
 ) -> *const c_char {
-    let variant_state: Response<VariantDef> = check_variant(ptr, toggle_name, context).into();
-    let json = serde_json::to_string(&variant_state).unwrap();
-    CString::new(json).unwrap().into_raw()
+    let result: Result<Option<VariantDef>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggle_name = get_str(toggle_name_ptr)?;
+        let context: Context = get_json(context_ptr)?;
+
+        Ok(engine.check_variant(toggle_name, &context))
+    })();
+
+    result_to_json_ptr(result)
 }
 
-unsafe fn check_variant(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
-    context: *const c_char,
-) -> Result<Option<VariantDef>, FFIError> {
-    let engine = if !ptr.is_null() {
-        &mut *(ptr as *mut EngineState)
-    } else {
-        return Err(FFIError::NullError("Null engine pointer".into()));
-    };
-
-    let toggle_name = if !toggle_name.is_null() {
-        CStr::from_ptr(toggle_name).to_str()?
-    } else {
-        return Err(FFIError::NullError("Null toggle name pointer".into()));
-    };
-
-    let context: Context = if !context.is_null() {
-        let context_str = CStr::from_ptr(context).to_str()?;
-        serde_json::from_str(context_str)?
-    } else {
-        return Err(FFIError::NullError("Null context pointer".into()));
-    };
-
-    Ok(engine.check_variant(toggle_name, &context))
-}
-
-/// Frees the memory allocated for a response message created by check_enabled and check_variant
+/// Frees the memory allocated for a response message created by `check_enabled` or `check_variant`.
 ///
 /// # Safety
-/// The passed pointer should be a valid pointer to a string allocated by check_enabled or check_variant,
-/// passing a null pointer is a no-op but passing an invalid pointer is undefined behavior.
+///
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
+///
+/// This function must be called correctly in order to deallocate the memory allocated for the response in
+/// the `check_enabled`, `check_variant`, `count_toggle`, `count_variant` and `get_metrics` functions.
+/// Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_free_response_message(ptr: *mut c_char) {
-    if ptr.is_null() {
+pub extern "C" fn free_response(response_ptr: *mut c_char) {
+    if response_ptr.is_null() {
         return;
     }
-    drop(CString::from_raw(ptr));
+    unsafe {
+        drop(CString::from_raw(response_ptr));
+    }
 }
 
 /// Marks a toggle as being counted for purposes of metrics. This function needs to be paired with a call
-/// to get_metrics at a later point in time to retrieve the metrics.
+/// to `get_metrics` at a later point in time to retrieve the metrics.
 ///
 /// # Safety
-/// If any of the arguments are a null pointer, this function becomes a no-op.
-/// The caller is responsible for ensuring that the pointer to the engine is a valid pointer to an EngineState
-/// and that the pointer to the toggle_name is a valid pointer to a C String.
-/// Failure to uphold these conditions may result in undefined behavior.
 ///
-/// This function does not allocate any resources which need to be manually freed later.
+/// The caller is responsible for ensuring all arguments (except the last one, `enabled`) are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
+///
+/// The caller is responsible for freeing the allocated memory. This can be done by calling
+/// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_count_toggle(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
+pub extern "C" fn count_toggle(
+    engine_ptr: *mut c_void,
+    toggle_name_ptr: *const c_char,
     enabled: bool,
-) {
-    if ptr.is_null() || toggle_name.is_null() {
-        return;
-    }
-    let state = &mut *(ptr as *mut EngineState);
-    let c_toggle_name = CStr::from_ptr(toggle_name);
+) -> *const c_char {
+    let result: Result<Option<()>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggle_name = get_str(toggle_name_ptr)?;
 
-    if let Ok(toggle_name) = c_toggle_name.to_str() {
-        state.count_toggle(toggle_name, enabled);
-    }
+        Ok(Some(engine.count_toggle(toggle_name, enabled)))
+    })();
+
+    result_to_json_ptr(result)
 }
 
 /// Marks a variant as being counted for purposes of metrics. This function needs to be paired with a call
-/// to get_metrics at a later point in time to retrieve the metrics.
+/// to `get_metrics` at a later point in time to retrieve the metrics.
 ///
 /// # Safety
-/// If any of the arguments are a null pointer, this function becomes a no-op.
-/// The caller is responsible for ensuring that the pointer to the engine is a valid pointer, and that the
-/// pointers to the toggle_name and variant_name are valid pointers to C Strings.
-/// Failure to uphold these conditions may result in undefined behavior.
 ///
-/// This function does not allocate any resources which need to be manually freed later.
-
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
+///
+/// The caller is responsible for freeing the allocated memory. This can be done by calling
+/// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_count_variant(
-    ptr: *mut c_void,
-    toggle_name: *const c_char,
-    variant_name: *const c_char,
-) {
-    if ptr.is_null() || variant_name.is_null() || toggle_name.is_null() {
-        return;
-    }
-    let state = &mut *(ptr as *mut EngineState);
-    let c_toggle_name = CStr::from_ptr(toggle_name);
-    let c_variant_name = CStr::from_ptr(variant_name);
+pub extern "C" fn count_variant(
+    engine_ptr: *mut c_void,
+    toggle_name_ptr: *const c_char,
+    variant_name_ptr: *const c_char,
+) -> *const c_char {
+    let result: Result<Option<()>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggle_name = get_str(toggle_name_ptr)?;
+        let variant_name = get_str(variant_name_ptr)?;
 
-    if let (Ok(toggle_name), Ok(variant_name)) = (c_toggle_name.to_str(), c_variant_name.to_str()) {
-        state.count_variant(toggle_name, variant_name);
-    }
+        Ok(Some(engine.count_variant(toggle_name, variant_name)))
+    })();
+
+    result_to_json_ptr(result)
 }
 
 /// Returns a JSON encoded string representing the number of times each toggle and variant has been
 /// counted since the last time this function was called.
 ///
 /// # Safety
-/// The passed pointer should be a valid pointer to an EngineState struct. This function may choose to
-/// return a null pointer if the passed pointer is null, or no metrics have been gathered since the last
-/// time this function was called. If a non null response is returned, the caller is responsible for freeing
-/// the memory allocated for the returned string by calling engine_free_response_message on the returned pointer.
+///
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
+///
+/// The caller is responsible for freeing the allocated memory, in case the response is not null. This can be done by calling
+/// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub unsafe extern "C" fn engine_get_metrics(ptr: *mut c_void) -> *mut c_char {
-    let metrics: Response<MetricBucket> = get_metrics(ptr).into();
-    let json = serde_json::to_string(&metrics).unwrap();
-    CString::new(json).unwrap().into_raw()
-}
+pub extern "C" fn get_metrics(engine_ptr: *mut c_void) -> *mut c_char {
+    let result: Result<Option<MetricBucket>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
 
-unsafe fn get_metrics(ptr: *mut c_void) -> Result<Option<MetricBucket>, FFIError> {
-    let engine = if !ptr.is_null() {
-        &mut *(ptr as *mut EngineState)
-    } else {
-        return Err(FFIError::NullError("Null engine pointer".into()));
-    };
+        Ok(engine.get_metrics())
+    })();
 
-    Ok(engine.get_metrics())
+    result_to_json_ptr(result)
 }
 
 #[cfg(test)]
@@ -316,12 +308,12 @@ mod tests {
     use unleash_types::client_features::{ClientFeature, ClientFeatures, Strategy};
     use unleash_yggdrasil::EngineState;
 
-    use crate::{engine_check_enabled, engine_new, Response, ResponseCode};
+    use crate::{check_enabled, new_engine, Response, ResponseCode};
 
     #[test]
     fn when_requesting_a_toggle_that_does_not_exist_then_a_response_with_no_error_and_not_found_is_returned(
     ) {
-        let engine_ptr = engine_new();
+        let engine_ptr = new_engine();
 
         let c_toggle_name = CString::new("some-toggle").unwrap();
         let c_context = CString::new("{}").unwrap();
@@ -330,7 +322,7 @@ mod tests {
         let context_ptr = c_context.as_ptr();
 
         unsafe {
-            let string_response = engine_check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
+            let string_response = check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
             let enabled_response: Response<bool> = serde_json::from_str(response).unwrap();
 
@@ -342,7 +334,7 @@ mod tests {
     #[test]
     fn when_requesting_a_toggle_that_does_exist_and_is_enabled_then_a_response_with_no_error_and_enabled_status_is_returned(
     ) {
-        let engine_ptr = engine_new();
+        let engine_ptr = new_engine();
         let toggle_under_test = "some-toggle";
 
         let c_toggle_name = CString::new(toggle_under_test).unwrap();
@@ -374,7 +366,7 @@ mod tests {
             let engine = &mut *(engine_ptr as *mut EngineState);
             engine.take_state(client_features);
 
-            let string_response = engine_check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
+            let string_response = check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
             let enabled_response: Response<bool> = serde_json::from_str(response).unwrap();
 
@@ -394,7 +386,7 @@ mod tests {
             let toggle_name_ptr = c_toggle_name.as_ptr();
             let context_ptr = c_context.as_ptr();
 
-            let string_response = engine_check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
+            let string_response = check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
             let enabled_response: Response<bool> = serde_json::from_str(response).unwrap();
 
@@ -405,7 +397,7 @@ mod tests {
 
     #[test]
     fn when_given_a_null_toggle_name_pointer_then_a_error_is_returned() {
-        let engine_ptr = engine_new();
+        let engine_ptr = new_engine();
 
         unsafe {
             let c_context = CString::new("{}").unwrap();
@@ -413,7 +405,7 @@ mod tests {
             let toggle_name_ptr = std::ptr::null();
             let context_ptr = c_context.as_ptr();
 
-            let string_response = engine_check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
+            let string_response = check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
             let enabled_response: Response<bool> = serde_json::from_str(response).unwrap();
 
@@ -424,7 +416,7 @@ mod tests {
 
     #[test]
     fn when_given_a_null_context_pointer_then_a_error_is_returned() {
-        let engine_ptr = engine_new();
+        let engine_ptr = new_engine();
 
         unsafe {
             let c_toggle_name = CString::new("some-toggle").unwrap();
@@ -432,7 +424,7 @@ mod tests {
             let toggle_name_ptr = c_toggle_name.as_ptr();
             let context_ptr = std::ptr::null();
 
-            let string_response = engine_check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
+            let string_response = check_enabled(engine_ptr, toggle_name_ptr, context_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
             let enabled_response: Response<bool> = serde_json::from_str(response).unwrap();
 

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -63,7 +63,7 @@ impl From<serde_json::Error> for FFIError {
     }
 }
 
-fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState, FFIError> {
+unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState, FFIError> {
     if engine_ptr.is_null() {
         Err(FFIError::NullError("Null engine pointer".into()))
     } else {
@@ -71,7 +71,7 @@ fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState, FFIErr
     }
 }
 
-fn get_str<'a>(ptr: *const c_char) -> Result<&'a str, FFIError> {
+unsafe fn get_str<'a>(ptr: *const c_char) -> Result<&'a str, FFIError> {
     if ptr.is_null() {
         Err(FFIError::NullError("Null pointer".into()))
     } else {
@@ -79,7 +79,7 @@ fn get_str<'a>(ptr: *const c_char) -> Result<&'a str, FFIError> {
     }
 }
 
-fn get_json<T: DeserializeOwned>(json_ptr: *const c_char) -> Result<T, FFIError> {
+unsafe fn get_json<T: DeserializeOwned>(json_ptr: *const c_char) -> Result<T, FFIError> {
     let json_str = get_str(json_ptr)?;
     serde_json::from_str(json_str).map_err(FFIError::from)
 }
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn free_engine(engine_ptr: *mut c_void) {
 /// but any invalid pointers will result in undefined behavior.
 /// These pointers should not be dropped for the lifetime of this function call.
 #[no_mangle]
-pub extern "C" fn take_state(engine_ptr: *mut c_void, json_ptr: *const c_char) -> *const c_char {
+pub unsafe extern "C" fn take_state(engine_ptr: *mut c_void, json_ptr: *const c_char) -> *const c_char {
     let result: Result<Option<()>, FFIError> = (|| {
         let engine = get_engine(engine_ptr)?;
         let toggles: ClientFeatures = get_json(json_ptr)?;
@@ -154,7 +154,7 @@ pub extern "C" fn take_state(engine_ptr: *mut c_void, json_ptr: *const c_char) -
 /// The caller is responsible for freeing the allocated memory. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub extern "C" fn check_enabled(
+pub unsafe extern "C" fn check_enabled(
     engine_ptr: *mut c_void,
     toggle_name_ptr: *const c_char,
     context_ptr: *const c_char,
@@ -182,7 +182,7 @@ pub extern "C" fn check_enabled(
 /// The caller is responsible for freeing the allocated memory. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub extern "C" fn check_variant(
+pub unsafe extern "C" fn check_variant(
     engine_ptr: *mut c_void,
     toggle_name_ptr: *const c_char,
     context_ptr: *const c_char,
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn free_response(response_ptr: *mut c_char) {
 /// The caller is responsible for freeing the allocated memory. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub extern "C" fn count_toggle(
+pub unsafe extern "C" fn count_toggle(
     engine_ptr: *mut c_void,
     toggle_name_ptr: *const c_char,
     enabled: bool,
@@ -260,7 +260,7 @@ pub extern "C" fn count_toggle(
 /// The caller is responsible for freeing the allocated memory. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub extern "C" fn count_variant(
+pub unsafe extern "C" fn count_variant(
     engine_ptr: *mut c_void,
     toggle_name_ptr: *const c_char,
     variant_name_ptr: *const c_char,
@@ -290,7 +290,7 @@ pub extern "C" fn count_variant(
 /// The caller is responsible for freeing the allocated memory, in case the response is not null. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
 #[no_mangle]
-pub extern "C" fn get_metrics(engine_ptr: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn get_metrics(engine_ptr: *mut c_void) -> *mut c_char {
     let result: Result<Option<MetricBucket>, FFIError> = (|| {
         let engine = get_engine(engine_ptr)?;
 


### PR DESCRIPTION
Attempts to refactor Yggdrasil's FFI layer after reading through the code.

I'm a bit unsure about the method renames. I wanted simpler names on the interface, but also noticed that simpler names sometimes meant unexpected problems.

I tried to be a bit more explicit about the unsafes by making their scope a lot tighter (only unsafe what we need to unsafe). I also updated the docs for the methods and tried to make them consistent. Added some helper methods for a DRY-er approach. Includes some renames, moving some things around and some small typo corrections.

Tests are green, both `cargo test` at the top level and `rspec` in `ruby-engine`.

I hope this makes sense but I'm totally OK with simply discarding this if we don't see value in it 🙂 