### PR TITLE
fix: non strategy variants will work with empty strategy variants

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1260,7 +1260,7 @@ mod test {
     }
 
     #[test]
-    pub fn do_the_thing() {
+    pub fn empty_strategy_variants_do_not_block_non_strategy_variants_from_working() {
         let raw_state = r#"
         {
             "version": 2,


### PR DESCRIPTION
This allows base variants to resolve correctly even when strategy variants are defined as an empty list. Previously, if Yggdrasil found a strategy variant set that was an empty list, it would short circuit to the disabled variant and not fallback to checking the base variants