### PR TITLE
feat: add dependent flags

### DIFF
--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v4.5.1
+          ref: v4.5.2
           path: client-specification
       - name: Run tests
         run: |

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v4.3.1
+          ref: v4.5.1
           path: client-specification
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy enough - run `cargo build` from the root of the project. You'll need an up 
 
 To run the client specs, you'll first need to clone them:
 
-`git clone --depth 5 --branch v4.3.1 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v4.5.1 https://github.com/Unleash/client-specification.git client-specification`
 
 ## Node
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy enough - run `cargo build` from the root of the project. You'll need an up 
 
 To run the client specs, you'll first need to clone them:
 
-`git clone --depth 5 --branch v4.5.1 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v4.5.2 https://github.com/Unleash/client-specification.git client-specification`
 
 ## Node
 

--- a/node-sdk/Cargo.toml
+++ b/node-sdk/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-unleash-types = "0.10.4"
+unleash-types = "0.10.5"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}
 serde-wasm-bindgen = "0.4.5"
 wasm-bindgen = "0.2.83"

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.0"
 lazy_static = "1.4.0"
 semver = "1.0.17"
 convert_case = "0.6.0"
-unleash-types = "0.10.4"
+unleash-types = "0.10.5"
 chrono = "0.4.26"
 dashmap = "5.5.0"
 

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -338,10 +338,10 @@ impl EngineState {
                             Some(variants) => {
                                 variants.contains(&self.get_variant(&parent.feature, &context).name)
                             }
-                            None => self.is_enabled(&parent.feature, &context),
+                            None => self.enabled(&parent_toggle, &context),
                         }
                     } else {
-                        !self.is_enabled(&parent.feature, &context)
+                        !self.enabled(&parent_toggle, &context)
                     }
                 })
             }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -27,7 +27,7 @@ use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
-pub const SUPPORTED_SPEC_VERSION: &str = "4.5.1";
+pub const SUPPORTED_SPEC_VERSION: &str = "4.5.2";
 
 pub struct CompiledToggle {
     pub name: String,

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -307,10 +307,6 @@ impl EngineState {
     }
 
     fn is_parent_dependency_satisfied(&self, toggle: &CompiledToggle, context: &Context) -> bool {
-        if toggle.dependencies.is_empty() {
-            return true;
-        }
-
         toggle.dependencies.iter().all(|parent| {
             let Some(parent_toggle) = self.get_toggle(&parent.feature) else {
                 return false;

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -27,7 +27,7 @@ use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
-pub const SUPPORTED_SPEC_VERSION: &str = "4.3.1";
+pub const SUPPORTED_SPEC_VERSION: &str = "4.5.1";
 
 pub struct CompiledToggle {
     pub name: String,
@@ -595,6 +595,7 @@ mod test {
     #[test_case("14-constraint-semver-operators.json"; "Semver constraints")]
     #[test_case("15-global-constraints.json"; "Segments")]
     #[test_case("16-strategy-variants.json"; "Strategy variants")]
+    #[test_case("17-dependent-features.json"; "Dependent features")]
     fn run_client_spec(spec_name: &str) {
         let spec = load_spec(spec_name);
         let mut engine = EngineState::default();

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1452,8 +1452,59 @@ mod test {
         state.is_enabled("some-toggle", &blank_context);
 
         let metrics = state.get_metrics().unwrap();
-        println!("metrics: {:#?}", metrics);
         assert_eq!(metrics.toggles.get("some-toggle").unwrap().yes, 1);
+        assert!(metrics.toggles.get("parent-flag").is_none());
+    }
+
+    #[test]
+    pub fn parent_flags_are_consulted_for_get_variant() {
+        let mut compiled_state = HashMap::new();
+        compiled_state.insert(
+            "some-toggle".to_string(),
+            CompiledToggle {
+                name: "some-toggle".into(),
+                enabled: true,
+                compiled_strategy: Box::new(|_| true),
+                variants: vec![CompiledVariant {
+                    name: "enabled-variant".into(),
+                    weight: 100,
+                    stickiness: None,
+                    payload: None,
+                    overrides: None,
+                }],
+                dependencies: vec![FeatureDependency {
+                    feature: "parent-flag".into(),
+                    enabled: Some(true),
+                    variants: Some(vec!["don't-ignore-me".into()]),
+                }],
+                ..CompiledToggle::default()
+            },
+        );
+
+        compiled_state.insert(
+            "parent-flag".to_string(),
+            CompiledToggle {
+                name: "parent-flag".into(),
+                enabled: false,
+                compiled_strategy: Box::new(|_| true),
+                variants: vec![],
+                ..CompiledToggle::default()
+            },
+        );
+
+        let mut state = EngineState {
+            compiled_state: Some(compiled_state),
+            ..Default::default()
+        };
+
+        let blank_context = Context::default();
+
+        let variant = state.get_variant("some-toggle", &blank_context);
+
+        assert_eq!(variant.name, "disabled");
+
+        let metrics = state.get_metrics().unwrap();
+        assert_eq!(metrics.toggles.get("some-toggle").unwrap().no, 1);
         assert!(metrics.toggles.get("parent-flag").is_none());
     }
 }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1385,7 +1385,7 @@ mod test {
                 variants: vec![],
                 dependencies: Some(vec![CompiledFeatureDependency {
                     feature: "parent-flag".into(),
-                    enabled: None,
+                    enabled: Some(true),
                     variants: None,
                 }]),
                 ..CompiledToggle::default()
@@ -1411,9 +1411,10 @@ mod test {
         let blank_context = Context::default();
 
         state.is_enabled("some-toggle", &blank_context);
+        state.is_enabled("parent-flag", &blank_context);
 
         let metrics = state.get_metrics().unwrap();
         assert_eq!(metrics.toggles.get("some-toggle").unwrap().yes, 1);
-        assert_eq!(metrics.toggles.get("parent-flag").unwrap().yes, 0);
+        assert_eq!(metrics.toggles.get("parent-flag").unwrap().yes, 1);
     }
 }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -401,7 +401,7 @@ impl EngineState {
         variants: &'a Vec<CompiledVariant>,
         context: &Context,
     ) -> Option<&'a CompiledVariant> {
-        if variants.is_empty() || !self.is_parent_dependency_satisfied(&toggle, &context) {
+        if variants.is_empty() {
             return None;
         }
         if let Some(found_override) = check_for_variant_override(variants, context) {

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -330,12 +330,12 @@ impl EngineState {
             if parent.enabled.unwrap_or(true) {
                 match parent.variants.as_ref() {
                     Some(variants) if !variants.is_empty() => {
-                        variants.contains(&self.get_variant(&parent.feature, &context).name)
+                        variants.contains(&self.get_variant(&parent.feature, context).name)
                     }
-                    _ => self.enabled(&parent_toggle, &context),
+                    _ => self.enabled(parent_toggle, context),
                 }
             } else {
-                !self.enabled(&parent_toggle, &context)
+                !self.enabled(parent_toggle, context)
             }
         })
     }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -137,19 +137,12 @@ pub fn compile_state(state: &ClientFeatures) -> HashMap<String, CompiledToggle> 
                 compiled_strategy: compile_rule(rule.as_str()).unwrap(),
                 impression_data: toggle.impression_data.unwrap_or_default(),
                 project: toggle.project.clone().unwrap_or("default".to_string()),
-                dependencies: compile_dependencies(&toggle.dependencies),
+                dependencies: toggle.dependencies.clone().unwrap_or_default(),
             },
         );
     }
 
     compiled_state
-}
-
-fn compile_dependencies(dependencies: &Option<Vec<FeatureDependency>>) -> Vec<FeatureDependency> {
-    match dependencies {
-        Some(variants) => variants.clone(),
-        _ => vec![],
-    }
 }
 
 fn compile_variants(variants: &Option<Vec<Variant>>) -> Vec<CompiledVariant> {
@@ -342,10 +335,9 @@ impl EngineState {
 
     fn enabled(&self, toggle: &CompiledToggle, context: &Context) -> bool {
         let enriched_context = EnrichedContext::from(context.clone(), toggle.name.clone());
-        match self.is_parent_dependency_satisfied(toggle, context) {
-            false => false,
-            true => toggle.enabled && (toggle.compiled_strategy)(&enriched_context),
-        }
+        toggle.enabled
+            && self.is_parent_dependency_satisfied(toggle, context)
+            && (toggle.compiled_strategy)(&enriched_context)
     }
 
     pub fn resolve_all(&self, context: &Context) -> Option<HashMap<String, ResolvedToggle>> {

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -320,15 +320,20 @@ impl EngineState {
                 return false;
             }
 
+            let parent_enabled = self.enabled(parent_toggle, context);
             if parent.enabled.unwrap_or(true) {
                 match parent.variants.as_ref() {
                     Some(variants) if !variants.is_empty() => {
-                        variants.contains(&self.get_variant(&parent.feature, context).name)
+                        parent_enabled
+                            && self
+                                .check_variant_by_toggle(parent_toggle, context)
+                                .map(|variant| variants.contains(&variant.name))
+                                .unwrap_or(true)
                     }
-                    _ => self.enabled(parent_toggle, context),
+                    _ => parent_enabled,
                 }
             } else {
-                !self.enabled(parent_toggle, context)
+                !parent_enabled
             }
         })
     }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1411,10 +1411,9 @@ mod test {
         let blank_context = Context::default();
 
         state.is_enabled("some-toggle", &blank_context);
-        state.is_enabled("parent-flag", &blank_context);
 
         let metrics = state.get_metrics().unwrap();
         assert_eq!(metrics.toggles.get("some-toggle").unwrap().yes, 1);
-        assert_eq!(metrics.toggles.get("parent-flag").unwrap().yes, 1);
+        assert!(metrics.toggles.get("parent-flag").is_none());
     }
 }

--- a/yggdrasilffi/Cargo.toml
+++ b/yggdrasilffi/Cargo.toml
@@ -14,5 +14,5 @@ name = "yggdrasilffi"
 libc = "0.2"
 serde_json = "1.0.68"
 serde = { version = "1.0.68", features = ["derive"] }
-unleash-types = "0.10.4"
+unleash-types = "0.10.5"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}


### PR DESCRIPTION
This PR adds dependent flags to Yggdrasil, complying with the updated client specs.

Regarding these extra points not covered by the spec:

- metrics are not called on dependent features :: this is covered and tested
- impression events are called on dependent features for easier debugging :: yggdrasil doesn't touch impression events 
- warning events for missing dependencies are reported once :: yggdrasil doesn't deal with warnings

@kwasniew , there is a [line in `resolveVariant` in the Node SDK](https://github.com/Unleash/unleash-client-node/blob/6bed4e7f9f1993fc2b6232da8fbbda03cdb3973a/src/client.ts#L238) that checks for parent dependencies being satisfied. What exactly does it do? I tried doing something similar here, but removed it because the tests pass either way. Is this an edge case not covered by the tests, or is it just that the implementations differ here?
