### PR TITLE
fix: allows current time to be assumed when calculating the context

### DIFF
--- a/unleash-yggdrasil/src/state.rs
+++ b/unleash-yggdrasil/src/state.rs
@@ -19,7 +19,10 @@ impl EnrichedContext {
             session_id: context.session_id.clone(),
             environment: context.environment.clone(),
             app_name: context.app_name.clone(),
-            current_time: context.current_time.clone(),
+            current_time: context
+                .current_time
+                .clone()
+                .or_else(|| Some(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string())),
             remote_address: context.remote_address.clone(),
             properties: context.properties,
             toggle_name,
@@ -31,4 +34,50 @@ impl EnrichedContext {
 pub enum SdkError {
     StrategyEvaluationError,
     StrategyParseError,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::strategy_parsing::compile_rule;
+
+    use super::*;
+    use unleash_types::client_features::Context;
+
+    #[test]
+    fn converting_a_context_to_enriched_context_assumes_now_for_time_if_not_set() {
+        let context = Context::default();
+        let enriched_context = EnrichedContext::from(context, "test".into());
+        chrono::DateTime::parse_from_rfc3339(
+            &enriched_context
+                .current_time
+                .clone()
+                .expect("current_time should be set"),
+        )
+        .expect("cannot parse retrieved dates");
+    }
+
+    #[test]
+    fn converting_a_context_to_enriched_context_leaves_current_time_alone_if_set() {
+        let context = Context {
+            current_time: Some("2020-01-01T00:00:00Z".into()),
+            ..Context::default()
+        };
+        let enriched_context = EnrichedContext::from(context, "test".into());
+        assert_eq!(
+            enriched_context
+                .current_time
+                .expect("current_time should be set"),
+            "2020-01-01T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn assumed_current_time_works_correctly_in_a_constraint() {
+        let rule_text = "current_time > 2023-10-13T10:19:22Z";
+        let rule = compile_rule(rule_text).unwrap();
+        let context = Context::default();
+        let enriched_context = EnrichedContext::from(context, "test".into());
+
+        assert!(rule(&enriched_context));
+    }
 }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -223,7 +223,7 @@ fn upgrade_constraint(constraint: &Constraint) -> String {
                     .collect::<Vec<String>>()
                     .join(", ")
             })
-            .unwrap_or_else(|| "".to_string());
+            .unwrap_or_default();
         format!("[{values}]")
     } else {
         if constraint.operator == Operator::SemverEq


### PR DESCRIPTION
Fixes an issue where Yggdrasil won't assume the current time for a context field, instead it expects the SDKs to send it as part of the context, which they never do.

This patches this to allow Yggdrasil to assume a current time of now if the current time field is not overridden on the context field