### PR TITLE
meta: add GitHub-cli as a dependency in devenv.nix

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,7 +5,9 @@
   # env.GREET = "devenv";
 
   # https://devenv.sh/packages/
-  # packages = [ pkgs.git ];
+  packages = [
+    pkgs.github-cli # required for the release process
+  ];
 
   # https://devenv.sh/scripts/
   # scripts.hello.exec = "echo hello from $GREET";


### PR DESCRIPTION
This adds the GitHub CLI as a dependency for nix users, so that we have the tools necessary for the release process.

Ideally, I'd like to add cargo smart-release, too, but it's not available on nixpkgs at the moment.