### PR TITLE
chore: apply rubocop format to Ruby engine

### DIFF
--- a/ruby-engine/lib/unleash_engine.rb
+++ b/ruby-engine/lib/unleash_engine.rb
@@ -85,6 +85,7 @@ class UnleashEngine
 
     raise "Error: #{response[:error_message]}" if response[:status_code] == ERROR_RESPONSE
     return nil if response[:status_code] == TOGGLE_MISSING_RESPONSE
+
     return response[:value] == true
   end
 

--- a/ruby-engine/scripts/mem_check.rb
+++ b/ruby-engine/scripts/mem_check.rb
@@ -6,34 +6,34 @@ require 'get_process_mem'
 unleash_engine = UnleashEngine.new
 
 def run_memory_check(lambda, method_name_being_tested)
-    puts "#{method_name_being_tested} Warming up"
+  puts "#{method_name_being_tested} Warming up"
 
-    ## This should give us a warmup baseline to allow the runtime to assgin whatever it needs
-    for i in 0..1000000
-        lambda.call
-    end
-    GC.start
+  ## This should give us a warmup baseline to allow the runtime to assgin whatever it needs
+  for i in 0..1000000
+    lambda.call
+  end
+  GC.start
 
-    ## Now we poke the memory - only memory we need for this call should be assigned now
-    ## everything else should be done in the previous warm up
-    pre_check_memory = GetProcessMem.new.mb
-    for i in 0..1000000
-        lambda.call
-    end
+  ## Now we poke the memory - only memory we need for this call should be assigned now
+  ## everything else should be done in the previous warm up
+  pre_check_memory = GetProcessMem.new.mb
+  for i in 0..1000000
+    lambda.call
+  end
 
-    GC.start
-    post_check_memory = GetProcessMem.new.mb
+  GC.start
+  post_check_memory = GetProcessMem.new.mb
 
-    puts "#{method_name_being_tested} Memory diff during enabled check: #{post_check_memory} #{pre_check_memory} MB"
-    diff = post_check_memory - pre_check_memory
-    if diff < 0.5
-        puts "#{method_name_being_tested} Memory diff is within half a MB, this is an expected range"
-    else
-        STDERR.puts "WARNING: LIKELY MEMORY LEAK DETECTED. THIS REQUIRES HUMAN ATTENTION"
-        STDERR.puts "#{method_name_being_tested} Memory diff is not within the expected half MB range, this likely indicates a leak within the engine"
-    end
+  puts "#{method_name_being_tested} Memory diff during enabled check: #{post_check_memory} #{pre_check_memory} MB"
+  diff = post_check_memory - pre_check_memory
+  if diff < 0.5
+    puts "#{method_name_being_tested} Memory diff is within half a MB, this is an expected range"
+  else
+    STDERR.puts "WARNING: LIKELY MEMORY LEAK DETECTED. THIS REQUIRES HUMAN ATTENTION"
+    STDERR.puts "#{method_name_being_tested} Memory diff is not within the expected half MB range, this likely indicates a leak within the engine"
+  end
 
-    puts "---"
+  puts "---"
 end
 
 suite_path = File.join('../client-specification/specifications', '01-simple-examples.json')

--- a/ruby-engine/spec/unleash_engine_spec.rb
+++ b/ruby-engine/spec/unleash_engine_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe UnleashEngine do
       unleash_engine.count_toggle(feature_name, true)
       unleash_engine.count_toggle(feature_name, false)
 
-      metrics =  unleash_engine.get_metrics() # This should clear the metrics buffer
+      metrics = unleash_engine.get_metrics() # This should clear the metrics buffer
 
       metric = metrics[:toggles][feature_name.to_sym]
       expect(metric[:yes]).to eq(1)
       expect(metric[:no]).to eq(1)
 
-      metrics =  unleash_engine.get_metrics()
+      metrics = unleash_engine.get_metrics()
       expect(metrics).to be_nil
     end
 
@@ -48,7 +48,7 @@ RSpec.describe UnleashEngine do
       unleash_engine.count_toggle(toggle_name, true)
       unleash_engine.count_toggle(toggle_name, false)
 
-      metrics =  unleash_engine.get_metrics()
+      metrics = unleash_engine.get_metrics()
       metric = metrics[:toggles][toggle_name.to_sym]
 
       expect(metric[:yes]).to eq(1)
@@ -61,7 +61,7 @@ RSpec.describe UnleashEngine do
       unleash_engine.count_toggle(toggle_name, true)
       unleash_engine.count_toggle(toggle_name, false)
 
-      metrics =  unleash_engine.get_metrics()
+      metrics = unleash_engine.get_metrics()
       metric = metrics[:toggles][toggle_name.to_sym]
 
       expect(metric[:yes]).to eq(1)
@@ -78,7 +78,7 @@ RSpec.describe UnleashEngine do
 
       unleash_engine.count_variant(toggle_name, 'disabled')
 
-      metrics =  unleash_engine.get_metrics()
+      metrics = unleash_engine.get_metrics()
       metric = metrics[:toggles][toggle_name.to_sym]
 
       expect(metric[:variants][:disabled]).to eq(1)

--- a/ruby-engine/unleash-engine.gemspec
+++ b/ruby-engine/unleash-engine.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
-    s.name        = 'unleash-engine'
-    s.version     = '0.0.1'
-    s.date        = '2023-06-28'
-    s.summary     = 'Unleash engine for evaluating feature toggles'
-    s.description = '...'
-    s.authors     = ['Your Name']
-    s.email       = 'you@example.com'
-    s.files       = Dir.glob("{lib,spec}/**/*") + ["README.md"] + Dir["lib/**/*", "ext/libyggdrasilffi.so"]
-    s.homepage    =
-      'http://github.com/username/my_gem'
-    s.license     = 'MIT'
+  s.name = 'unleash-engine'
+  s.version     = '0.0.1'
+  s.date        = '2023-06-28'
+  s.summary     = 'Unleash engine for evaluating feature toggles'
+  s.description = '...'
+  s.authors     = ['Your Name']
+  s.email       = 'you@example.com'
+  s.files       = Dir.glob("{lib,spec}/**/*") + ["README.md"] + Dir["lib/**/*", "ext/libyggdrasilffi.so"]
+  s.homepage    =
+    'http://github.com/username/my_gem'
+  s.license     = 'MIT'
 
-    s.add_dependency "ffi", "~> 1.15.5"
-    s.add_dependency "fiddle", "~> 1.0.6"
-  end
+  s.add_dependency "ffi", "~> 1.15.5"
+  s.add_dependency "fiddle", "~> 1.0.6"
+end


### PR DESCRIPTION
Applies `rubocop --fix` to the Ruby engine