### PR TITLE
refactor: fix normalized hash result to start from 1 instead of 0

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -426,7 +426,7 @@ impl EngineState {
         let mut total_weight = 0;
         for variant in variants {
             total_weight += variant.weight as u32;
-            if total_weight > target {
+            if total_weight >= target {
                 return Some(variant);
             }
         }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -37,7 +37,7 @@ pub fn normalized_hash(
     seed: u32,
 ) -> std::io::Result<u32> {
     let mut reader = Cursor::new(format!("{}:{}", &group, &identifier));
-    murmur3_32(&mut reader, seed).map(|hash_result| hash_result % modulus)
+    murmur3_32(&mut reader, seed).map(|hash_result| hash_result % modulus + 1)
 }
 
 pub type RuleFragment = Box<dyn SendableFragment + Send + Sync + 'static>;


### PR DESCRIPTION
To align it with rest of SDKs, hash result should start from index 1 instead of 0.