### PR TITLE
chore: set workspace resolver to 2 explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
   "unleash-yggdrasil",


### PR DESCRIPTION
Sets workspace resolver to 2. Workspace v1 is deprecated and the warnings are getting annoying