### PR TITLE
chore: custom strategy placeholder

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -15,7 +15,7 @@ public class Tests
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    [Test] 
+    [Test]
     public void MassTestMemoryUsage() {
         // Arrange
         var basePath = Path.Combine("..", "..", "..", "..", "..", "..", "client-specification", "specifications");

--- a/dotnet-engine/Yggdrasil.Engine/FFILinux.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFILinux.cs
@@ -25,14 +25,14 @@ internal class FFILinux : IFFIAccess {
         return take_state(ptr, json);
     }
 
-    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context)
+    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_enabled(ptr, toggle_name, context);
+        return check_enabled(ptr, toggle_name, context, customStrategyResults);
     }
 
-    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context) 
+    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_variant(ptr, toggle_name, context);
+        return check_variant(ptr, toggle_name, context, customStrategyResults);
     }
 
     public void FreeResponse(IntPtr ptr)
@@ -60,10 +60,10 @@ internal class FFILinux : IFFIAccess {
     internal static extern IntPtr take_state(IntPtr ptr, string json);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
     internal static extern void free_response(IntPtr ptr);

--- a/dotnet-engine/Yggdrasil.Engine/FFIMacOS.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIMacOS.cs
@@ -25,14 +25,14 @@ internal class FFIMacOS : IFFIAccess {
         return take_state(ptr, json);
     }
 
-    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context)
+    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_enabled(ptr, toggle_name, context);
+        return check_enabled(ptr, toggle_name, context, customStrategyResults);
     }
 
-    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context) 
+    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_variant(ptr, toggle_name, context);
+        return check_variant(ptr, toggle_name, context, customStrategyResults);
     }
 
     public void FreeResponse(IntPtr ptr)
@@ -60,10 +60,10 @@ internal class FFIMacOS : IFFIAccess {
     internal static extern IntPtr take_state(IntPtr ptr, string json);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
     internal static extern void free_response(IntPtr ptr);

--- a/dotnet-engine/Yggdrasil.Engine/FFIWin.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIWin.cs
@@ -27,14 +27,14 @@ internal class FFIWin : IFFIAccess {
         return take_state(ptr, json);
     }
 
-    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context)
+    public IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_enabled(ptr, toggle_name, context);
+        return check_enabled(ptr, toggle_name, context, customStrategyResults);
     }
 
-    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context) 
+    public IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
-        return check_variant(ptr, toggle_name, context);
+        return check_variant(ptr, toggle_name, context, customStrategyResults);
     }
 
     public void FreeResponse(IntPtr ptr)
@@ -62,10 +62,10 @@ internal class FFIWin : IFFIAccess {
     internal static extern IntPtr take_state(IntPtr ptr, string json);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
-    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context);
+    internal static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     [DllImport(DLL_PATH)]
     internal static extern void free_response(IntPtr ptr);

--- a/dotnet-engine/Yggdrasil.Engine/IFFIAccess.cs
+++ b/dotnet-engine/Yggdrasil.Engine/IFFIAccess.cs
@@ -7,9 +7,9 @@ internal interface IFFIAccess {
 
     IntPtr TakeState(IntPtr ptr, string json);
 
-    IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context);
+    IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
-    IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context);
+    IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
 
     void FreeEngine(IntPtr ptr);
 

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
@@ -14,7 +14,7 @@ public class YggdrasilEngine
 
     private IFFIAccess platformEngine;
 
-    private static IFFIAccess GetPlatformEngine() { 
+    private static IFFIAccess GetPlatformEngine() {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
             return new FFILinux();
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
@@ -66,7 +66,7 @@ public class YggdrasilEngine
     {
         string contextJson = JsonSerializer.Serialize(context, options);
 
-        var isEnabledPtr = platformEngine.CheckEnabled(state, toggleName, contextJson);
+        var isEnabledPtr = platformEngine.CheckEnabled(state, toggleName, contextJson, "{}");
 
         if (isEnabledPtr == IntPtr.Zero)
         {
@@ -92,7 +92,7 @@ public class YggdrasilEngine
     public Variant? GetVariant(string toggleName, Context context)
     {
         var contextJson = JsonSerializer.Serialize(context, options);
-        var variantPtr = platformEngine.CheckVariant(state, toggleName, contextJson);
+        var variantPtr = platformEngine.CheckVariant(state, toggleName, contextJson, "{}");
 
         if (variantPtr == IntPtr.Zero)
         {
@@ -118,7 +118,7 @@ public class YggdrasilEngine
         var metricsPtr = platformEngine.GetMetrics(state);
 
         if (metricsPtr == IntPtr.Zero)
-        {   
+        {
             return null;
         }
 

--- a/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
+++ b/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
@@ -40,7 +40,7 @@ public class UnleashEngine {
     public Boolean isEnabled(String name, Context context) throws YggdrasilInvalidInputException, YggdrasilError {
         try {
             String jsonContext = writer.writeValueAsString(context);
-            YggResponse<Boolean> isEnabled = read(yggdrasil.checkEnabled(name, jsonContext), new TypeReference<>() {});
+            YggResponse<Boolean> isEnabled = read(yggdrasil.checkEnabled(name, jsonContext, "{}"), new TypeReference<>() {});
             return isEnabled.getValue();
         } catch (JsonProcessingException e) {
             throw new YggdrasilInvalidInputException(context);
@@ -50,7 +50,7 @@ public class UnleashEngine {
     public VariantDef getVariant(String name, Context context) throws YggdrasilInvalidInputException, YggdrasilError {
         try {
             String jsonContext = writer.writeValueAsString(context);
-            YggResponse<VariantDef> response = read(yggdrasil.checkVariant(name, jsonContext), new TypeReference<>() {});
+            YggResponse<VariantDef> response = read(yggdrasil.checkVariant(name, jsonContext, "{}"), new TypeReference<>() {});
             return response.getValue();
         } catch (JsonProcessingException e) {
             throw new YggdrasilInvalidInputException(context);

--- a/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
+++ b/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
@@ -16,9 +16,9 @@ interface UnleashFFI extends Library {
 
     Pointer take_state(Pointer ptr, String toggles);
 
-    Pointer check_enabled(Pointer ptr, String name, String context);
+    Pointer check_enabled(Pointer ptr, String name, String context, String customStrategyResults);
 
-    Pointer check_variant(Pointer ptr, String name, String context);
+    Pointer check_variant(Pointer ptr, String name, String context, String customStrategyResults);
 
     void count_toggle(Pointer ptr, String name, boolean enabled);
 
@@ -29,7 +29,7 @@ interface UnleashFFI extends Library {
     void free_response(Pointer pointer);
 }
 
-class YggdrasilFFI  {
+class YggdrasilFFI {
     private static final Cleaner CLEANER = Cleaner.create();
     @SuppressWarnings("unused")
     private final Cleaner.Cleanable cleanable;
@@ -47,7 +47,7 @@ class YggdrasilFFI  {
         if (libraryPath == null) {
             libraryPath = "."; // assume it's accessible in current path
         }
-        System.out.println("Loading library from "+Paths.get(libraryPath).toAbsolutePath());
+        System.out.println("Loading library from " + Paths.get(libraryPath).toAbsolutePath());
         String libImpl = "libyggdrasilffi.so";
         if (Platform.isMac()) {
             libImpl = "libyggdrasilffi.dylib";
@@ -68,8 +68,10 @@ class YggdrasilFFI  {
         this.enginePtr = this.ffi.new_engine();
 
         // Note that the cleaning action must not refer to the object being registered.
-        // If so, the object will not become phantom reachable and the cleaning action will not be invoked automatically.
-        // this.cleanable uses a PhantomReference to this object, so from a GC perspective it doesn't count.
+        // If so, the object will not become phantom reachable and the cleaning action
+        // will not be invoked automatically.
+        // this.cleanable uses a PhantomReference to this object, so from a GC
+        // perspective it doesn't count.
         this.cleanable = CLEANER.register(this, new YggdrasilNativeLibraryResourceCleaner(this.ffi, this.enginePtr));
     }
 
@@ -81,12 +83,12 @@ class YggdrasilFFI  {
         this.ffi.free_response(response);
     }
 
-    Pointer checkEnabled(String name, String context){
-        return this.ffi.check_enabled(this.enginePtr, name, context);
+    Pointer checkEnabled(String name, String context, String customStrategyResults) {
+        return this.ffi.check_enabled(this.enginePtr, name, context, customStrategyResults);
     }
 
-    Pointer checkVariant(String name, String context){
-        return this.ffi.check_variant(this.enginePtr, name, context);
+    Pointer checkVariant(String name, String context, String customStrategyResults) {
+        return this.ffi.check_variant(this.enginePtr, name, context, customStrategyResults);
     }
 
     void countToggle(String flagName, boolean enabled) {


### PR DESCRIPTION
This makes the .NET and Java engines run their tests again after the implementation of custom strategies. This does **not** implement custom strategies, just gives us a green build and test