### PR TITLE
refactor: no warnings please

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -77,7 +77,7 @@ public class Tests
                 var toggleName = (string)test["toggleName"];
                 var expectedResult = (bool)test["expectedResult"];
 
-                var result = yggdrasilEngine.IsEnabled(toggleName, context) ?? false;
+                var result = yggdrasilEngine.IsEnabled(toggleName, context!) ?? false;
 
                 Assert.AreEqual(expectedResult, result, message: $"Failed client specification '{suite}': Failed test '{test["description"]}': expected {expectedResult}, got {result}");
             }
@@ -91,7 +91,7 @@ public class Tests
                 // Silly hack to apply formatting to the string from the spec
                 var expectedResult = JsonSerializer.Serialize(JsonSerializer.Deserialize<Variant>(test["expectedResult"].ToString(), options), options);
 
-                var result = yggdrasilEngine.GetVariant(toggleName, context) ?? new Variant { Name = "disabled", Payload = null, Enabled = false };
+                var result = yggdrasilEngine.GetVariant(toggleName, context!) ?? new Variant { Name = "disabled", Payload = null, Enabled = false };
                 var jsonResult = JsonSerializer.Serialize(result, options);
 
                 Assert.AreEqual(expectedResult, jsonResult, message: $"Failed client specification '{suite}': Failed test '{test["description"]}': expected {expectedResult}, got {result}");

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -89,8 +89,13 @@ internal static class FFI
         else
             throw new PlatformNotSupportedException("Unsupported platform");
 
-        string assemblyLocation = Assembly.GetExecutingAssembly().Location;
-        string assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+        string assemblyLocation =
+            Assembly.GetExecutingAssembly().Location
+            ?? throw new InvalidOperationException("Could not find assembly location");
+
+        string assemblyDirectory =
+            Path.GetDirectoryName(assemblyLocation)
+            ?? throw new InvalidOperationException("Could not find assembly directory");
 
         return Path.Combine(assemblyDirectory, libraryName);
     }

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace Yggdrasil;
 
-public class Context
+public sealed class Context
 {
     public string? UserId { get; set; }
     public string? SessionId { get; set; }
@@ -13,7 +13,8 @@ public class Context
     public Dictionary<string, string>? Properties { get; set; }
 }
 
-public class EngineResponse {
+public class EngineResponse
+{
     [JsonPropertyName("error_message")]
     public string? ErrorMessage { get; set; }
 
@@ -21,21 +22,22 @@ public class EngineResponse {
     public string? StatusCode { get; set; }
 }
 
-public class EngineResponse<TValue> : EngineResponse {
+public class EngineResponse<TValue> : EngineResponse
+{
     public TValue? Value { get; set; }
 }
 
-public class Variant
+public sealed class Variant
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public Payload? Payload { get; set; }
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = false;
 }
 
-public class Payload
+public sealed class Payload
 {
-    public string? PayloadType { get; set; }
-    public string? Value { get; set; }
+    public string PayloadType { get; set; } = null!;
+    public string Value { get; set; } = null!;
 
     public override bool Equals(object? obj)
     {
@@ -45,25 +47,35 @@ public class Payload
         var payload = (Payload)obj;
         return Value == payload.Value && PayloadType == payload.PayloadType;
     }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 23 + (Value?.GetHashCode() ?? 0);
+            hash = hash * 23 + (PayloadType?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
 }
 
 public class YggdrasilEngineException : Exception
 {
-    public YggdrasilEngineException(string message) : base(message) { }
+    public YggdrasilEngineException(string message)
+        : base(message) { }
 }
 
-public class FeatureCount
+public sealed class FeatureCount
 {
-    public long Yes { get; set; }
-    public long No { get; set; }
-    public Dictionary<string, long> Variants { get; set; }
+    public long Yes { get; set; } = 0;
+    public long No { get; set; } = 0;
+    public Dictionary<string, long> Variants { get; set; } = new Dictionary<string, long>();
 }
 
-
-public class MetricsBucket
+public sealed class MetricsBucket
 {
-    public Dictionary<string, FeatureCount> Toggles { get; set; }
-
-    public DateTimeOffset Start { get; set; }
-    public DateTimeOffset Stop { get; set; }
+    public Dictionary<string, FeatureCount> Toggles { get; set; } = null!;
+    public DateTimeOffset Start { get; set; } = DateTimeOffset.MinValue;
+    public DateTimeOffset Stop { get; set; } = DateTimeOffset.MinValue;
 }


### PR DESCRIPTION
Removes a bunch of places where the compiler was complaining about potential nulls and seals a few publicly facing classes. Also adds a hashcode method where we implemented equals

Just future proofing before we get runnaway compiler warnings and it becomes hard to fix