### PR TITLE
feat: add shouldemitimpressionevents to yggdrasil and .NET wrapper

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using NUnit.Framework;
 using System;
 using Newtonsoft.Json.Linq;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Yggdrasil;
 
 
@@ -101,4 +100,67 @@ public class Tests
         }
     }
 
+    [Test]
+    public void Impression_Data_Test_Enabled() {
+        var testDataObject = new {
+            Version = 2,
+            Features = new [] {
+                new {
+                    Name = "with.impression.data",
+                    Type = "release",
+                    Enabled = true,
+                    ImpressionData = true,
+                    Strategies = new [] {
+                        new {
+                            Name = "default",
+                            Parameters = new Dictionary<string, string>()
+                        }
+                    }
+                }
+            }
+        };
+
+        var testData = JsonSerializer.Serialize(testDataObject, options);
+        var engine = new YggdrasilEngine();
+        engine.TakeState(testData);
+        var featureName = "with.impression.data";
+        var result = engine.IsEnabled(featureName, new Context());
+        var shouldEmit = engine.ShouldEmitImpressionEvent(featureName);
+        Assert.NotNull(result);
+        Assert.IsTrue(result);
+        Assert.NotNull(shouldEmit);
+        Assert.IsTrue(shouldEmit);
+    }
+
+    [Test]
+    public void Impression_Data_Test_Disabled() {
+        var testDataObject = new {
+            Version = 2,
+            Features = new [] {
+                new {
+                    Name = "with.impression.data.false",
+                    Type = "release",
+                    Enabled = true,
+                    ImpressionData = false,
+                    Strategies = new [] {
+                        new {
+                            Name = "default",
+                            Parameters = new Dictionary<string, string>()
+                        }
+                    }
+                }
+            }
+        };
+
+        var testData = JsonSerializer.Serialize(testDataObject, options);
+        var engine = new YggdrasilEngine();
+        engine.TakeState(testData);
+        var featureName = "with.impression.data.false";
+        var result = engine.IsEnabled(featureName, new Context());
+        var shouldEmit = engine.ShouldEmitImpressionEvent(featureName);
+        Assert.NotNull(result);
+        Assert.IsTrue(result);
+        Assert.NotNull(shouldEmit);
+        Assert.IsFalse(shouldEmit);
+    }
 }

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -24,6 +24,7 @@ internal static class FFI
     private delegate void FreeResponseDelegate(IntPtr ptr);
     private delegate void CountToggleDelegate(IntPtr ptr, string toggle_name, bool enabled);
     private delegate void CountVariantDelegate(IntPtr ptr, string toggle_name, string variant_name);
+    private delegate bool ShouldEmitImpressionEventDelegate(IntPtr ptr, string toggle_name);
 
     private static readonly NewEngineDelegate _newEngine;
     private static readonly FreeEngineDelegate _freeEngine;
@@ -34,6 +35,7 @@ internal static class FFI
     private static readonly FreeResponseDelegate _free_response;
     private static readonly CountToggleDelegate _count_toggle;
     private static readonly CountVariantDelegate _count_variant;
+    private static readonly ShouldEmitImpressionEventDelegate _should_emit_impression_event;
 
     static FFI()
     {
@@ -74,6 +76,10 @@ internal static class FFI
 
         _count_variant = Marshal.GetDelegateForFunctionPointer<CountVariantDelegate>(
             NativeLibrary.GetExport(libHandle, "count_variant")
+        );
+
+        _should_emit_impression_event = Marshal.GetDelegateForFunctionPointer<ShouldEmitImpressionEventDelegate>(
+            NativeLibrary.GetExport(libHandle, "should_emit_impression_event")
         );
     }
 
@@ -148,5 +154,10 @@ internal static class FFI
     public static void CountVariant(IntPtr ptr, string toggle_name, string variant_name)
     {
         _count_variant(ptr, toggle_name, variant_name);
+    }
+
+    public static bool ShouldEmitImpressionEvent(IntPtr ptr, string toggle_name)
+    {
+        return _should_emit_impression_event(ptr, toggle_name);
     }
 }

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
@@ -17,6 +17,11 @@ public class YggdrasilEngine
         state = FFI.NewEngine();
     }
 
+    public bool ShouldEmitImpressionEvent(string featureName)
+    {
+        return FFI.ShouldEmitImpressionEvent(state, featureName);
+    }
+
     public void Dispose()
     {
         FFI.FreeEngine(this.state);

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -398,6 +398,15 @@ impl EngineState {
         })
     }
 
+    pub fn should_emit_impression_event(
+        &self,
+        name: &str,
+    ) -> bool {
+        self.compiled_state.as_ref().and_then(|state| {
+            state.get(name).map(|compiled_toggle| compiled_toggle.impression_data)
+        }).unwrap_or_default()
+    }
+
     pub fn check_enabled(
         &self,
         name: &str,

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -312,6 +312,29 @@ pub unsafe extern "C" fn get_metrics(engine_ptr: *mut c_void) -> *mut c_char {
     result_to_json_ptr(result)
 }
 
+/// Lets you know whether impression events are enabled for this toggle or not.
+/// Returns false in case of error or if the toggle is not found.
+///
+/// # Safety
+///
+/// The caller is responsible for ensuring the engine_ptr is a valid pointer to an unleash engine.
+/// An invalid pointer to unleash engine will result in undefined behaviour.
+/// Null pointers will result in a false return value without undefined behaviour. 
+#[no_mangle]
+pub unsafe extern "C" fn should_emit_impression_event(
+    engine_ptr: *mut c_void,
+    toggle_name_ptr: *const c_char
+) -> bool {
+    let result: Result<bool, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let toggle_name = get_str(toggle_name_ptr)?;
+
+        Ok(engine.should_emit_impression_event(toggle_name))
+    })();
+
+    result.unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::{CStr, CString};


### PR DESCRIPTION
## About the changes

This PR adds support to Yggdrasil for checking whether impression events should be emitted for specified feature toggle.

This PR also adds this capability to the .NET Yggdrasil wrapper

## WIP
- Lacks unit tests