### PR TITLE
fix: make free floating quotes in string operators work correctly

### DIFF
--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -206,7 +206,8 @@ fn string(node: Pair<Rule>) -> String {
     let mut chars = node.as_str().chars();
     chars.next();
     chars.next_back();
-    chars.as_str().into()
+    let string: String = chars.as_str().into();
+    string.replace("\\\"", "\"")
 }
 
 //Constraints
@@ -908,5 +909,14 @@ mod tests {
 
         assert!(true_result);
         assert!(!false_result);
+    }
+
+    #[test]
+    fn evaluates_quotes_in_stringy_rules_correctly() {
+        let rule = compile_rule("user_id contains_any [\"some\\\"thing\"]").unwrap();
+
+        let context = context_from_user_id("some\"thing");
+
+        assert!(rule(&context));
     }
 }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -264,7 +264,7 @@ fn is_stringy(op: &Operator) -> bool {
 }
 
 fn escape_quotes(stringy_operator: &str) -> String {
-    stringy_operator.replace("\"", "\\\"")
+    stringy_operator.replace('\"', "\\\"")
 }
 
 fn upgrade_constraint(constraint: &Constraint) -> String {


### PR DESCRIPTION
This makes the rule upgrader escape incoming string operators if they contain free floating quotes. So this:

`user_id in [" look me Im "cool"  "]`
Should escape to :
`user_id in [" look me Im \"cool\"  "]`

This then gets removed during evaluation phase so that we don't have to escape quotes in the context