### PR TITLE
chore: build dependents on ygg

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - 'dotnet-engine/**'
+      # Build in main if anything changes in yggdrasil or the ffi layer
+      - 'unleash-yggdrasil/src/**.rs'
+      - 'yggdrasilffi/src/**.rs'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - 'java-engine/**.java'
+      # Build in main if anything changes in yggdrasil or the ffi layer
+      - 'unleash-yggdrasil/src/**.rs'
+      - 'yggdrasilffi/src/**.rs'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -6,8 +6,14 @@ on:
       - main
     paths:
       - 'wasm-engine/**'
+      # Build in main if anything changes in yggdrasil or the ffi layer
+      - 'unleash-yggdrasil/src/**.rs'
+      - 'yggdrasilffi/src/**.rs'
     tags:
       - '*'
+  pull_request:
+    paths:
+      - 'wasm-engine/**'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
When Yggdrasil or the FFI changes, build the dependent sub-projects. This will give us a fast feedback loop without having to build them in every PR