### PR TITLE
feat: add feature_enabled to variant response

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
 
       - name: Set up .NET

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
 
       - name: Setup Java

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy enough - run `cargo build --release` from the root of the project. You'll n
 
 To run the client specs, you'll first need to clone them:
 
-`git clone --depth 5 --branch v5.0.2 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v5.1.0 https://github.com/Unleash/client-specification.git client-specification`
 
 ## Testing
 

--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -96,7 +96,7 @@ public class Tests
         // Silly hack to apply formatting to the string from the spec
         var expectedResult = JsonSerializer.Serialize(JsonSerializer.Deserialize<Variant>(test["expectedResult"].ToString(), options), options);
 
-        var result = yggdrasilEngine.GetVariant(toggleName, context) ?? new Variant("disabled", null, false);
+        var result = yggdrasilEngine.GetVariant(toggleName, context) ?? new Variant("disabled", null, false, yggdrasilEngine.IsEnabled(toggleName, context) ?? false);
         var jsonResult = JsonSerializer.Serialize(result, options);
 
         Assert.AreEqual(expectedResult, jsonResult, message: $"Failed client specification '{suite}': Failed test '{test["description"]}': expected {expectedResult}, got {result}");

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -29,16 +29,19 @@ public class EngineResponse<TValue> : EngineResponse
 
 public class Variant
 {
-  public Variant(string name, Payload? payload, bool enabled)
+  public Variant(string name, Payload? payload, bool enabled, bool featureEnabled)
   {
     Name = name;
     Payload = payload;
     Enabled = enabled;
+    FeatureEnabled = featureEnabled;
   }
 
   public string Name { get; set; }
   public Payload? Payload { get; set; }
   public bool Enabled { get; set; }
+  [JsonPropertyName("feature_enabled")]
+  public bool FeatureEnabled { get; set; }
 }
 
 public class Payload

--- a/go-engine/unleash_engine.go
+++ b/go-engine/unleash_engine.go
@@ -45,9 +45,10 @@ func (e *UnleashEngine) IsEnabled(toggleName string, context *Context) bool {
 }
 
 type VariantDef struct {
-	Name    string   `json:"name,omitempty"`
-	Payload *Payload `json:"payload,omitempty"`
-	Enabled bool     `json:"enabled,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	Payload        *Payload `json:"payload,omitempty"`
+	Enabled        bool     `json:"enabled,omitempty"`
+	FeatureEnabled bool     `json:"featureEnabled,omitempty"`
 }
 
 type Payload struct {

--- a/go-engine/unleash_engine_test.go
+++ b/go-engine/unleash_engine_test.go
@@ -226,6 +226,9 @@ func TestClientSpecification(t *testing.T) {
 				if result.Enabled != expectedVariant.Enabled {
 					t.Fatalf("Failed variant test '%s': expected variant enabled %v, got %v", testMap["description"], expectedVariant.Enabled, result.Enabled)
 				}
+				if result.FeatureEnabled != expectedVariant.FeatureEnabled {
+					t.Fatalf("Failed variant test '%s': expected variant feature_enabled %v, got %v", testMap["description"], expectedVariant.FeatureEnabled, result.FeatureEnabled)
+				}
 				if result.Payload != nil && expectedVariant.Payload != nil {
 					if result.Payload.Value != expectedVariant.Payload.Value {
 						t.Fatalf("Failed variant test '%s': expected variant payload %s, got %s", testMap["description"], expectedVariant.Payload, result.Payload)

--- a/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
+++ b/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
@@ -7,15 +7,18 @@ public class VariantDef {
     private final String name;
     private final Payload payload;
     private final Boolean enabled;
+    private final Boolean featureEnabled;
 
     @JsonCreator
     VariantDef(
             @JsonProperty("name") String name,
             @JsonProperty("payload") Payload payload,
-            @JsonProperty("enabled") Boolean enabled) {
+            @JsonProperty("enabled") Boolean enabled,
+            @JsonProperty("feature_enabled") Boolean featureEnabled) {
         this.name = name;
         this.payload = payload;
         this.enabled = enabled;
+        this.featureEnabled = featureEnabled;
     }
 
     public String getName() {
@@ -28,5 +31,9 @@ public class VariantDef {
 
     public Boolean isEnabled() {
         return enabled;
+    }
+
+    public Boolean isFeatureEnabled() {
+        return featureEnabled;
     }
 }

--- a/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
+++ b/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
@@ -1,9 +1,8 @@
 package io.getunleash.engine;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
 
 public class VariantDef {
     private final String name;

--- a/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
+++ b/java-engine/src/main/java/io/getunleash/engine/VariantDef.java
@@ -1,5 +1,7 @@
 package io.getunleash.engine;
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -18,7 +20,7 @@ public class VariantDef {
         this.name = name;
         this.payload = payload;
         this.enabled = enabled;
-        this.featureEnabled = featureEnabled;
+        this.featureEnabled = Optional.ofNullable(featureEnabled).orElse(false);
     }
 
     public String getName() {

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -32,8 +32,6 @@ class TestSuite {
 
 class UnleashEngineTest {
 
-    private static final VariantDef DEFAULT_VARIANT = new VariantDef("disabled", null, false, false);
-
     // Assume this is set up to be your feature JSON
     private final String simpleFeatures =
             loadFeaturesFromFile("../client-specification/specifications/01-simple-examples.json");
@@ -89,7 +87,8 @@ class UnleashEngineTest {
         VariantDef variant = engine.getVariant("Feature.A", context);
 
         if (variant == null) {
-            variant = DEFAULT_VARIANT;
+            variant =
+                    new VariantDef("disabled", null, false, engine.isEnabled("Feature.A", context));
         }
 
         assertEquals("disabled", variant.getName());
@@ -147,7 +146,13 @@ class UnleashEngineTest {
                     VariantDef result = engine.getVariant(toggleName, context);
                     if (result == null) {
                         // this behavior should be implemented in the SDK
-                        result = DEFAULT_VARIANT;
+                        result =
+                                new VariantDef(
+                                        "disabled",
+                                        null,
+                                        false,
+                                        engine.isEnabled(toggleName, context));
+                        ;
                     }
 
                     String expectedResultJson = objectMapper.writeValueAsString(expectedResult);

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -32,7 +32,7 @@ class TestSuite {
 
 class UnleashEngineTest {
 
-    private static final VariantDef DEFAULT_VARIANT = new VariantDef("disabled", null, false);
+    private static final VariantDef DEFAULT_VARIANT = new VariantDef("disabled", null, false, false);
 
     // Assume this is set up to be your feature JSON
     private final String simpleFeatures =

--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -25,6 +25,7 @@ def to_variant(raw_variant)
     name: raw_variant[:name],
     enabled: raw_variant[:enabled],
     payload: payload,
+    feature_enabled: raw_variant[:feature_enabled]
   }
 end
 

--- a/ruby-engine/spec/yggdrasil_engine_spec.rb
+++ b/ruby-engine/spec/yggdrasil_engine_spec.rb
@@ -125,12 +125,14 @@ RSpec.describe 'Client Specification' do
             result = yggdrasil_engine.get_variant(toggle_name, context) || {
               :name => 'disabled',
               :payload => nil,
-              :enabled => false
+              :enabled => false,
+              :feature_enabled => unleash_engine.enabled?(toggle_name, context) || false
             }
 
             expect(result[:name]).to eq(expected_result[:name])
             expect(result[:payload]).to eq(expected_result[:payload])
             expect(result[:enabled]).to eq(expected_result[:enabled])
+            expect(result[:feature_enabled]).to eq(expected_result[:feature_enabled])
           end
         end
       end

--- a/ruby-engine/spec/yggdrasil_engine_spec.rb
+++ b/ruby-engine/spec/yggdrasil_engine_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Client Specification' do
               :name => 'disabled',
               :payload => nil,
               :enabled => false,
-              :feature_enabled => unleash_engine.enabled?(toggle_name, context) || false
+              :feature_enabled => yggdrasil_engine.enabled?(toggle_name, context) || false
             }
 
             expect(result[:name]).to eq(expected_result[:name])

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -325,7 +325,7 @@ impl EngineState {
 
             let parent_enabled = self.enabled(compiled_parent, context, &None); //parent toggles explicitly don't support custom strategies
             let expected_parent_enabled_state = parent_dependency.enabled.unwrap_or(true);
-            let parent_variant = self.check_variant_by_toggle(compiled_parent, context);
+            let parent_variant = self.check_variant_by_toggle(compiled_parent, context, parent_enabled);
 
             let is_variant_dependency_satisfied = {
                 if let (Some(expected_variants), Some(actual_variant)) =
@@ -471,6 +471,7 @@ impl EngineState {
         &self,
         toggle: &CompiledToggle,
         context: &Context,
+        is_enabled: bool,
     ) -> Option<VariantDef> {
         let strategy_variants =
             toggle
@@ -498,7 +499,7 @@ impl EngineState {
             name: variant.name.clone(),
             payload: variant.payload.clone(),
             enabled: true,
-            feature_enabled: true,
+            feature_enabled: is_enabled.clone(),
         })
     }
 
@@ -510,7 +511,7 @@ impl EngineState {
     ) -> Option<VariantDef> {
         self.get_toggle(name).and_then(|toggle| {
             if self.enabled(toggle, context, external_values) {
-                self.check_variant_by_toggle(toggle, context)
+                self.check_variant_by_toggle(toggle, context, true)
             } else {
                 None
             }
@@ -530,9 +531,7 @@ impl EngineState {
             self.count_toggle(name, enabled);
 
             if enabled {
-                let mut variant = self.check_variant_by_toggle(toggle, context).unwrap_or_default();
-                variant.feature_enabled = true;
-                Some(variant)
+                self.check_variant_by_toggle(toggle, context, true)
             } else {
                 None
             }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -543,7 +543,6 @@ impl EngineState {
         .unwrap_or_default();
 
         self.count_variant(name, &variant.name);
-        println!("Returning variant with feature_enabled: {}", &variant.feature_enabled);
         variant
     }
 

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -532,7 +532,6 @@ impl EngineState {
             if enabled {
                 let mut variant = self.check_variant_by_toggle(toggle, context).unwrap_or_default();
                 variant.feature_enabled = true;
-                println!("Setting feature_enabled");
                 Some(variant)
             } else {
                 None

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -499,7 +499,7 @@ impl EngineState {
             name: variant.name.clone(),
             payload: variant.payload.clone(),
             enabled: true,
-            feature_enabled: is_enabled.clone(),
+            feature_enabled: is_enabled,
         })
     }
 

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -495,6 +495,12 @@ impl EngineState {
             self.resolve_variant(&toggle.variants, &toggle.name, context)
         };
 
+        if variant.is_none() {
+            let mut disabled_variant = VariantDef::default();
+            disabled_variant.feature_enabled = is_enabled;
+            return Some(disabled_variant)
+        }
+
         variant.map(|variant| VariantDef {
             name: variant.name.clone(),
             payload: variant.payload.clone(),


### PR DESCRIPTION
https://linear.app/unleash/issue/SR-158/yggdrasil-edge-add-feature-enabled-property-to-variant-response

Bumps the client spec and adds a new `feature_enabled` property to the variant response, similar to what we've done for other SDKs.