### PR TITLE
fix: use absolutepath, fixing path in macos

### DIFF
--- a/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
+++ b/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
@@ -62,7 +62,7 @@ class YggdrasilFFI {
             libImpl = "libyggdrasilffi.dll";
         }
 
-        String combinedPath = Paths.get(libraryPath, libImpl).toString();
+        String combinedPath = Paths.get(libraryPath, libImpl).toAbsolutePath().toString();
         return Native.load(combinedPath, UnleashFFI.class);
     }
 


### PR DESCRIPTION
Fixes the path in MacOS, like mentioned in https://github.com/Unleash/yggdrasil/pull/91#discussion_r1394103945