### PR TITLE
feat(yggdrasil): Bubble up errors on take state

### DIFF
--- a/unleash-yggdrasil/benches/benchmark.rs
+++ b/unleash-yggdrasil/benches/benchmark.rs
@@ -10,16 +10,18 @@ fn is_enabled(engine: &EngineState, toggle_name: &str, context: &Context) {
 
 fn benchmark_with_no_strategy(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
-        version: 2,
-        features: vec![ClientFeature {
-            name: "test".into(),
-            enabled: true,
-            ..ClientFeature::default()
-        }],
-        segments: None,
-        query: None,
-    });
+    engine
+        .take_state(ClientFeatures {
+            version: 2,
+            features: vec![ClientFeature {
+                name: "test".into(),
+                enabled: true,
+                ..ClientFeature::default()
+            }],
+            segments: None,
+            query: None,
+        })
+        .unwrap();
     let context = Context {
         user_id: None,
         session_id: None,
@@ -36,31 +38,33 @@ fn benchmark_with_no_strategy(c: &mut Criterion) {
 
 fn benchmark_with_single_constraint(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
-        version: 2,
-        features: vec![ClientFeature {
-            name: "test".into(),
-            enabled: true,
-            strategies: Some(vec![Strategy {
-                name: "default".into(),
-                segments: None,
-                variants: None,
-                constraints: Some(vec![Constraint {
-                    context_name: "userId".into(),
-                    operator: Operator::In,
-                    case_insensitive: false,
-                    inverted: false,
-                    values: Some(vec!["7".into()]),
-                    value: None,
+    engine
+        .take_state(ClientFeatures {
+            version: 2,
+            features: vec![ClientFeature {
+                name: "test".into(),
+                enabled: true,
+                strategies: Some(vec![Strategy {
+                    name: "default".into(),
+                    segments: None,
+                    variants: None,
+                    constraints: Some(vec![Constraint {
+                        context_name: "userId".into(),
+                        operator: Operator::In,
+                        case_insensitive: false,
+                        inverted: false,
+                        values: Some(vec!["7".into()]),
+                        value: None,
+                    }]),
+                    parameters: None,
+                    sort_order: None,
                 }]),
-                parameters: None,
-                sort_order: None,
-            }]),
-            ..ClientFeature::default()
-        }],
-        segments: None,
-        query: None,
-    });
+                ..ClientFeature::default()
+            }],
+            segments: None,
+            query: None,
+        })
+        .unwrap();
     let context = Context {
         user_id: Some("7".into()),
         session_id: None,
@@ -77,41 +81,43 @@ fn benchmark_with_single_constraint(c: &mut Criterion) {
 
 fn benchmark_with_two_constraints(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
-        version: 2,
-        features: vec![ClientFeature {
-            name: "test".into(),
-            enabled: true,
-            strategies: Some(vec![Strategy {
-                name: "default".into(),
-                segments: None,
-                constraints: Some(vec![
-                    Constraint {
-                        context_name: "userId".into(),
-                        operator: Operator::In,
-                        case_insensitive: false,
-                        inverted: false,
-                        values: Some(vec!["7".into()]),
-                        value: None,
-                    },
-                    Constraint {
-                        context_name: "userId".into(),
-                        operator: Operator::NotIn,
-                        case_insensitive: false,
-                        inverted: false,
-                        values: Some(vec!["8".into()]),
-                        value: None,
-                    },
-                ]),
-                variants: None,
-                parameters: None,
-                sort_order: None,
-            }]),
-            ..ClientFeature::default()
-        }],
-        segments: None,
-        query: None,
-    });
+    engine
+        .take_state(ClientFeatures {
+            version: 2,
+            features: vec![ClientFeature {
+                name: "test".into(),
+                enabled: true,
+                strategies: Some(vec![Strategy {
+                    name: "default".into(),
+                    segments: None,
+                    constraints: Some(vec![
+                        Constraint {
+                            context_name: "userId".into(),
+                            operator: Operator::In,
+                            case_insensitive: false,
+                            inverted: false,
+                            values: Some(vec!["7".into()]),
+                            value: None,
+                        },
+                        Constraint {
+                            context_name: "userId".into(),
+                            operator: Operator::NotIn,
+                            case_insensitive: false,
+                            inverted: false,
+                            values: Some(vec!["8".into()]),
+                            value: None,
+                        },
+                    ]),
+                    variants: None,
+                    parameters: None,
+                    sort_order: None,
+                }]),
+                ..ClientFeature::default()
+            }],
+            segments: None,
+            query: None,
+        })
+        .unwrap();
     let context = Context {
         user_id: Some("7".into()),
         session_id: None,

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1431,6 +1431,73 @@ mod test {
     }
 
     #[test]
+    pub fn invalid_date_format_bubbles_up_a_nice_error_message() {
+        let raw_state = r#"
+        {
+            "version": 2,
+            "segments": [
+                {
+                    "id": 0,
+                    "name": "hasEnoughWins",
+                    "description": null,
+                    "constraints": [
+                        {
+                            "contextName": "dateLastWin",
+                            "operator": "DATE_AFTER",
+                            "value": "2022-05-01T12:00:00",
+                            "inverted": false,
+                            "caseInsensitive": true
+                        }
+                    ]
+                }
+            ],
+            "features": [
+                {
+                    "name": "toggle1",
+                    "type": "release",
+                    "enabled": true,
+                    "project": "TestProject20",
+                    "stale": false,
+                    "strategies": [
+                        {
+                            "name": "default",
+                            "segments": [
+                                0
+                            ]
+                        }
+                    ],
+                    "variants": [],
+                    "description": null,
+                    "impressionData": false
+                }
+            ],
+            "query": {
+                "environment": "development",
+                "inlineSegmentConstraints": true
+            },
+            "meta": {
+                "revisionId": 12137,
+                "etag": "\"76d8bb0e:12137\"",
+                "queryHash": "76d8bb0e"
+            }
+        }
+        "#;
+
+        let feature_set: ClientFeatures = serde_json::from_str(raw_state).unwrap();
+        let mut engine = EngineState::default();
+
+        let maybe_error = engine.take_state(feature_set);
+
+        if let Err(error) = maybe_error {
+            let error_as_string = format!("{:?}", error);
+            // TODO make error message better
+            assert!(error_as_string.contains("StrategyParseError"));
+        } else {
+            panic!("Expected an error from yggdrasil take state but got an Ok instead!")
+        }
+    }
+
+    #[test]
     pub fn metrics_are_not_recorded_for_parent_flags() {
         let mut compiled_state = HashMap::new();
         compiled_state.insert(

--- a/unleash-yggdrasil/src/state.rs
+++ b/unleash-yggdrasil/src/state.rs
@@ -36,10 +36,11 @@ impl EnrichedContext {
     }
 }
 
+
 #[derive(Debug)]
 pub enum SdkError {
     StrategyEvaluationError,
-    StrategyParseError,
+    StrategyParseError(String),
 }
 
 #[cfg(test)]

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -244,15 +244,20 @@ fn date_constraint(inverted: bool, mut node: Pairs<Rule>) -> RuleFragment {
         let context_value = context_getter(context);
         match context_value {
             Some(context_value) => {
-                let context_value: DateTime<Utc> = context_value.parse().unwrap();
-                match ordinal_operation {
-                    OrdinalComparator::Lte => context_value <= date,
-                    OrdinalComparator::Lt => context_value < date,
-                    OrdinalComparator::Gte => context_value >= date,
-                    OrdinalComparator::Gt => context_value > date,
-                    OrdinalComparator::Eq => context_value == date,
+                let context_value = context_value.parse::<DateTime<Utc>>();
+
+                if let Ok(context_value) = context_value {
+                    match ordinal_operation {
+                        OrdinalComparator::Lte => context_value <= date,
+                        OrdinalComparator::Lt => context_value < date,
+                        OrdinalComparator::Gte => context_value >= date,
+                        OrdinalComparator::Gt => context_value > date,
+                        OrdinalComparator::Eq => context_value == date,
+                    }
+                    .invert(inverted)
+                } else {
+                    false
                 }
-                .invert(inverted)
             }
             None => false,
         }


### PR DESCRIPTION
When taking state, different types of parsing errors can happen. In such situations, Yggdrasil should fail gracefully communicate the error to the client.