### PR TITLE
feat: add feature enabled property to variant checks 

### DIFF
--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
       - name: Run tests
         run: |


### PR DESCRIPTION
This add the enabled status of the toggle to the response in get_variant and does effectively the same logic in the FFI layers. This is a redesign of https://github.com/Unleash/yggdrasil/pull/91, to make the variant handling code a little less invasive and a little safer. This is the important PR since it allows us to do this in Edge.

Notably this does not handle the new property in the `check_variant` method in the core layer of Yggdrasil, instead it makes this the FFI layers problem, which I think is okay, since the FFI code has all the information it needs to be able to determine this. This is encoded in the type signatures of the respective methods so it should be tough to misuse.

Handling code for Java, Ruby and Dotnet is in other PRs to make this easier to review. Patches for the incomplete engines has been abandoned since they need a rewrite anyway. None of the FFI engines are in production so it should be safe to split