### PR TITLE
feat(dotnet): add variant enabled response

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
 
       - name: Set up .NET

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.0.2
+          ref: v5.1.0
           path: client-specification
       - name: Run tests
         run: |

--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -96,7 +96,8 @@ public class Tests
                 // Silly hack to apply formatting to the string from the spec
                 var expectedResult = JsonSerializer.Serialize(JsonSerializer.Deserialize<Variant>(test["expectedResult"].ToString(), options), options);
 
-                var result = yggdrasilEngine.GetVariant(toggleName, context) ?? new Variant("disabled", null, false);
+                var enabled = yggdrasilEngine.IsEnabled(toggleName, context) ?? false;
+                var result = yggdrasilEngine.GetVariant(toggleName, context) ?? new Variant("disabled", null, false, enabled);
                 var jsonResult = JsonSerializer.Serialize(result, options);
 
                 Assert.AreEqual(expectedResult, jsonResult, message: $"Failed client specification '{suite}': Failed test '{test["description"]}': expected {expectedResult}, got {result}");

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -29,7 +29,7 @@ public class EngineResponse<TValue> : EngineResponse
 
 public class Variant
 {
-  public Variant(string name, Payload? payload, bool enabled, bool featureEnabled)
+    public Variant(string name, Payload? payload, bool enabled, bool featureEnabled)
     {
         Name = name;
         Payload = payload;

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -29,16 +29,19 @@ public class EngineResponse<TValue> : EngineResponse
 
 public class Variant
 {
-    public Variant(string name, Payload? payload, bool enabled)
+  public Variant(string name, Payload? payload, bool enabled, bool featureEnabled)
     {
         Name = name;
         Payload = payload;
         Enabled = enabled;
+        FeatureEnabled = featureEnabled;
     }
 
     public string Name { get; set; }
     public Payload? Payload { get; set; }
     public bool Enabled { get; set; }
+    [JsonPropertyName("feature_enabled")]
+    public bool FeatureEnabled { get; set; }
 }
 
 public class Payload


### PR DESCRIPTION
Depends on https://github.com/Unleash/yggdrasil/pull/98

Basically just allows that to propagate out. Shameless stolen from https://github.com/Unleash/yggdrasil/pull/91