### PR TITLE
fix(core): hostname strategy should now work correctly

### DIFF
--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -982,9 +982,9 @@ mod tests {
 
     #[test]
     fn hostname_constraint_ignores_casing() {
-        std::env::set_var("hostname", "DoS");
+        std::env::set_var("hostname", "DaRWin");
 
-        let rule = compile_rule("hostname in [\"dOS\", \"pop-os\"]").unwrap();
+        let rule = compile_rule("hostname in [\"dArWin\", \"pop-os\"]").unwrap();
         let context = Context::default();
         assert!(rule(&context));
 

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -869,7 +869,7 @@ mod tests {
 
         let output = upgrade(&vec![strategy], &HashMap::new());
         assert!(compile_rule(&output).is_ok());
-        assert_eq!(output.as_str(), "remote_address in [\"DOS\", \"pop-os\"]");
+        assert_eq!(output.as_str(), "hostname in [\"DOS\", \"pop-os\"]");
     }
 
     #[test_case("gradualRolloutUserId")]

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -251,7 +251,7 @@ fn upgrade_hostname(strategy: &Strategy) -> String {
         .map(|x| format!("\"{x}\""))
         .collect::<Vec<String>>()
         .join(", ");
-    format!("remote_address in [{hosts}]")
+    format!("hostname in [{hosts}]")
 }
 
 fn upgrade_random(strategy: &Strategy) -> String {


### PR DESCRIPTION
This fixes a few silly mistakes in the hostname strategy (my bad).

- Hostname strategy should now be generated correctly in the upgrade path, rather than creating a remote address strategy
- Hostname strategy should now completely ignore casing
- Hostname strategy in Rust land should check `hostname` and not `HOSTNAME`