### PR TITLE
feat(core): patch remote address strategy to handle subnets

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -21,6 +21,7 @@ unleash-types = "0.10.6"
 chrono = "0.4.31"
 dashmap = "5.5.0"
 hostname = "0.3.1"
+ipnetwork = "0.20.0"
 
 [dependencies.serde]
 features = ["derive"]

--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -64,6 +64,7 @@ constraint = {
     invert_operation* ~
     (
         rollout_constraint
+        | ip_constraint
         | hostname_constraint
         | date_constraint
         | semver_constraint
@@ -78,6 +79,8 @@ constraint = {
     hostname_constraint = { hostname ~ in ~ string_list }
         hostname = _{ "hostname" }
         in = _{ "in" }
+    ip_constraint = { context_value ~ ip_contains_operation ~ string_list }
+        ip_contains_operation = _{ "contains_ip" }
     string_fragment_constraint = { context_value ~ ( string_list_operation_without_case | string_list_operation ) ~ string_list }
     list_constraint = { context_value ~ list_operation ~ ( numeric_list | string_list | empty_list ) }
     date_constraint = { context_value ~ ordinal_operation ~ date }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -207,7 +207,7 @@ fn upgrade_remote_address(strategy: &Strategy) -> String {
                 .map(|x| format!("\"{x}\""))
                 .collect::<Vec<String>>()
                 .join(", ");
-            format!("remote_address in [{ips}]")
+            format!("remote_address contains_ip [{ips}]")
         }
         None => "false".into(),
     }
@@ -919,5 +919,26 @@ mod tests {
         };
         let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
         assert_eq!(rule.as_str(), "false");
+    }
+
+    #[test]
+    fn remote_address_strategy_upgrades_to_ip_contains_constraint() {
+        let strategy = Strategy {
+            name: "remoteAddress".into(),
+            parameters: Some(
+                vec![("IPs".into(), "192.168.0.1, 192.168.0.2, 192.168.0.3".into())]
+                    .into_iter()
+                    .collect(),
+            ),
+            constraints: None,
+            segments: None,
+            sort_order: None,
+            variants: None,
+        };
+        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        assert_eq!(
+            rule.as_str(),
+            "remote_address contains_ip [\"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"]"
+        );
     }
 }


### PR DESCRIPTION
# What 

This adds a special constraint for remote address matching. This will check both IPv4 and and IPv6 addresses and respects subnet masks. 

# The Ugly

This builds an entirely different strategy for ip address, which treats ip addresses as strings within the parser and converts them to actual ip addresses in the compiler layer. I'd very much like to not do this, unfortunately, there's no validation in the Unleash layer to check that the ip addresses listed in the strategy are valid ip addresses, which means that treating these as ips in the parser runs the risk of breaking the entire strategy.

I think we'll have to run with this until we can deprecate the existing non validated remote address strategy
