### PR TITLE
chore(dotnet): prebuild yggdrasil on Debug build

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -12,6 +12,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <Target Name="YggdrasilPreBuild" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+    <Exec Command="
+      cd ../../ 
+      cargo build --release" />
+  </Target>
+
   <ItemGroup>
     <Content Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
## About the changes

Runs the Yggdrasil cargo build --release on dotnet build as a prebuilt step when building as debug (should help local dev)