### PR TITLE
chore(yggdrasil): add a failing test to demonstrate missing variants …

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1668,8 +1668,9 @@ mod test {
     }
 
     #[test]
-    pub fn strategy_variants_are_selected_over_base_variants_if_present_and_also_when_previous_failing_strategy_has_none() {
-      let raw_state = r#"
+    pub fn strategy_variants_are_selected_over_base_variants_if_present_and_also_when_previous_failing_strategy_has_none(
+    ) {
+        let raw_state = r#"
       {
           "version": 2,
           "features": [
@@ -1744,19 +1745,18 @@ mod test {
       }
       "#;
 
-      let feature_set: ClientFeatures = serde_json::from_str(raw_state).unwrap();
-      let mut engine = EngineState::default();
-      let context = Context {
-          ..Context::default()
-      };
+        let feature_set: ClientFeatures = serde_json::from_str(raw_state).unwrap();
+        let mut engine = EngineState::default();
+        let context = Context {
+            ..Context::default()
+        };
 
-      engine.take_state(feature_set).unwrap();
+        engine.take_state(feature_set).unwrap();
 
-      let results = engine.resolve_all(&context, &None);
-      let targeted_toggle = results.unwrap().get("toggle1").unwrap().clone();
+        let results = engine.resolve_all(&context, &None);
+        let targeted_toggle = results.unwrap().get("toggle1").unwrap().clone();
 
-      assert!(targeted_toggle.enabled);
-      assert_eq!(targeted_toggle.variant.name, "theselectedone");
-  }
-
+        assert!(targeted_toggle.enabled);
+        assert_eq!(targeted_toggle.variant.name, "theselectedone");
+    }
 }

--- a/unleash-yggdrasil/src/state.rs
+++ b/unleash-yggdrasil/src/state.rs
@@ -36,7 +36,6 @@ impl EnrichedContext {
     }
 }
 
-
 #[derive(Debug)]
 pub enum SdkError {
     StrategyEvaluationError,

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -376,7 +376,7 @@ mod tests {
     };
     use unleash_yggdrasil::{EngineState, ExtendedVariantDef};
 
-    use crate::{check_enabled, new_engine, Response, ResponseCode, check_variant};
+    use crate::{check_enabled, check_variant, new_engine, Response, ResponseCode};
 
     #[test]
     fn when_requesting_a_toggle_that_does_not_exist_then_a_response_with_no_error_and_not_found_is_returned(
@@ -563,7 +563,8 @@ mod tests {
             let string_response =
                 check_variant(engine_ptr, toggle_name_ptr, context_ptr, results_ptr);
             let response = CStr::from_ptr(string_response).to_str().unwrap();
-            let variant_response: Response<ExtendedVariantDef> = serde_json::from_str(response).unwrap();
+            let variant_response: Response<ExtendedVariantDef> =
+                serde_json::from_str(response).unwrap();
 
             assert!(variant_response.status_code == ResponseCode::Ok);
             let variant_response = variant_response.value.expect("Expected variant response");


### PR DESCRIPTION
## About the changes

adds a failing test to demonstrate missing variants in failing strategy breaking flow

## Discussion points

I think this one is good to iron out, do we have an issue with this in other SDKs? How is this meant to work?