### PR TITLE
fix(ruby): works on jruby

### DIFF
--- a/ruby-engine/Gemfile
+++ b/ruby-engine/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 # Gemfile
 
 gem "ffi"
-gem "fiddle"
 group :development do
   gem "get_process_mem", "~> 0.2.7"
 end

--- a/ruby-engine/Gemfile.lock
+++ b/ruby-engine/Gemfile.lock
@@ -2,18 +2,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     ffi (1.16.3)
-    fiddle (1.1.1)
+    ffi (1.16.3-java)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
 
 PLATFORMS
   arm64-darwin-22
+  universal-java-1.8
   x86_64-linux
 
 DEPENDENCIES
   ffi
-  fiddle
   get_process_mem (~> 0.2.7)
 
 BUNDLED WITH
-   2.4.13
+   2.3.27

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -11,6 +11,5 @@ Gem::Specification.new do |s|
     'http://github.com/username/my_gem'
   s.license     = 'MIT'
 
-  s.add_dependency "ffi", "~> 1.15.5"
-  s.add_dependency "fiddle", "~> 1.0.6"
+  s.add_dependency "ffi", "~> 1.15.5"  
 end


### PR DESCRIPTION
This strips an unnecessary dependency from the Ruby engine that was blocking Yggdrasil from working on JRuby (pretty sure this means Rubinus will work too but we don't guarantee that as a target and I haven't and am not intending to test that). 

Most of the changes here are as a result of tooling setting up the necessary changes to pull the equivalent native interfaces here for the JVM