### PR TITLE
fix: isolate toggle failures

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -1702,37 +1702,27 @@ mod test {
             "features": [
               {
                 "name": "Should_always_be_off",
-                "type": "permission",
                 "enabled": true,
-                "project": "test",
-                "stale": false,
                 "strategies": [
                   {
                     "name": "userWithId",
-                    "constraints": [],
                     "parameters": {
                       "userIds": "[\"this\",\"is\",\"broken\"]"
                     }
                   }
-                ],
-                "variants": []
+                ]
               },
               {
                 "name": "This_should_be_okay",
-                "type": "permission",
                 "enabled": true,
-                "project": "test",
-                "stale": false,
                 "strategies": [
                   {
                     "name": "userWithId",
-                    "constraints": [],
                     "parameters": {
                       "userIds": "this,is,okay"
                     }
                   }
-                ],
-                "variants": []
+                ]
               }
             ]
           }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -941,4 +941,26 @@ mod tests {
             "remote_address contains_ip [\"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"]"
         );
     }
+
+    #[test]
+    fn produces_compilable_rule_from_incorrectly_formatted_user_id_strategy_parameters() {
+        let strategy = Strategy {
+            name: "userWithId".into(),
+            parameters: Some(
+                vec![("userIds".into(), "[\"123\",\"456\",\"789\"]".into())]
+                    .into_iter()
+                    .collect(),
+            ),
+            constraints: None,
+            segments: None,
+            sort_order: None,
+            variants: None,
+        };
+
+        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+
+        assert!(compile_rule(&rule).is_ok());
+
+        assert_eq!(rule.as_str(), "user_id in [\"[\\\"123\\\"\",\"\\\"456\\\"\",\"\\\"789\\\"]\"]");
+    }
 }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -187,7 +187,10 @@ fn upgrade_user_id_strategy(strategy: &Strategy) -> String {
         Some(user_ids) => {
             let user_ids = user_ids
                 .split(',')
-                .map(|id| format!("\"{}\"", id.trim()))
+                //The escaping of quotes is to tolerate a legacy validation in bug in the Unleash server,
+                // which would save an incorrect parameter set for the strategy. This will still likely
+                // cause Yggdrasil to evalute the strategy as off for most cases, but it will allow the rule to compile
+                .map(|id| format!("\"{}\"", escape_quotes(id.trim())))
                 .collect::<Vec<String>>()
                 .join(",");
             format!("user_id in [{user_ids}]")


### PR DESCRIPTION
This makes two patches to Yggdrasil's strategy parsing flow:

1) Toggles will no longer affect each other during compilation. Previously, a toggle with an invalid rule would fail the entire response. Now that single toggle will default to false and others will compile correctly.This should be very rare
2) The user id strategy is more tolerant to failure in it's parameters - specifically, it'll escape cases where Unleash would sometimes save and send an incorrect set of parameters

This does have the side effect of preventing major issues in the grammar from bubbling in a meaningful way. Unfortunately, standard logging frameworks do not play nicely with cross compilation to WASM and writing to std out/err can cause problems when done from guest binaries when using FFI. This is fixable, but it requires a better pattern to bubble partial failures, that's bigger than this PR.

Update: #122  Makes errors bubble correctly again