### PR TITLE
refactor: better handling for unwrapping grammar

### DIFF
--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -46,13 +46,8 @@ pub fn normalized_hash(
     murmur3_32(&mut reader, seed).map(|hash_result| hash_result % modulus + 1)
 }
 
-fn drain<const N: usize>(mut node: Pairs<Rule>) -> [Pair<Rule>; N] {
-    let mut results = vec![];
-    for _ in 0..N {
-        results.push(node.next().unwrap());
-    }
-    let array: [Pair<Rule>; N] = results.try_into().unwrap();
-    array
+fn drain<const N: usize>(node: Pairs<Rule>) -> [Pair<Rule>; N] {
+    drain_partial(node).0
 }
 
 fn drain_partial<const N: usize>(mut node: Pairs<Rule>) -> ([Pair<Rule>; N], Pairs<Rule>) {

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -53,9 +53,13 @@ fn drain<const N: usize>(node: Pairs<Rule>) -> [Pair<Rule>; N] {
 fn drain_partial<const N: usize>(mut node: Pairs<Rule>) -> ([Pair<Rule>; N], Pairs<Rule>) {
     let mut results = vec![];
     for _ in 0..N {
-        results.push(node.next().unwrap());
+        results.push(node.next().expect(&format!(
+            "Expected at least {N} elements when parsing the following pairs {node:?}"
+        )));
     }
-    let array: [Pair<Rule>; N] = results.try_into().unwrap();
+    let array: [Pair<Rule>; N] = results.try_into().expect(&format!(
+        "Expected exactly {N} elements when parsing the following pairs {node:?}"
+    ));
     (array, node)
 }
 


### PR DESCRIPTION
There's a common pattern in the rule parser where we need to unpack x number of nodes from the parent into the children nodes, e.g. the hostname constraint, which has 3 children (you can see that from the grammar itself):

`hostname_constraint = { hostname ~ in ~ string_list }`

So we see this:

```
   let name = node.next().unwrap();
   let operator = node.next().unwrap();
   let list = node.next().unwrap();
```

This is safe so long as you know the correct number of nodes and hold to that but this unwrapping pattern is error prone (you need to get exactly the correct number of nodes or risk a panic). 

This PR swaps out this pattern in the code to go through a single function that does this unwrapping, now all those unwraps area together so we can beat them with the `Result` stick.

This gets pattern gets built on in #122 to completely eliminate the panicking code