### PR TITLE
fix: improves edge case handling in rule parsing  

### DIFF
--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -46,13 +46,8 @@ pub fn normalized_hash(
     murmur3_32(&mut reader, seed).map(|hash_result| hash_result % modulus + 1)
 }
 
-fn drain<const N: usize>(mut node: Pairs<Rule>) -> [Pair<Rule>; N] {
-    let mut results = vec![];
-    for _ in 0..N {
-        results.push(node.next().unwrap());
-    }
-    let array: [Pair<Rule>; N] = results.try_into().unwrap();
-    array
+fn drain<const N: usize>(node: Pairs<Rule>) -> [Pair<Rule>; N] {
+    drain_partial(node).0
 }
 
 fn drain_partial<const N: usize>(mut node: Pairs<Rule>) -> ([Pair<Rule>; N], Pairs<Rule>) {

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -215,14 +215,14 @@ fn to_string_comparator(node: Pair<Rule>) -> StringComparatorType {
     }
 }
 
-fn numeric(node: Pair<Rule>) -> Result<f64, SdkError> {
+fn numeric(node: Pair<Rule>) -> CompileResult<f64> {
     let value = node.as_str();
     value.parse::<f64>().map_err(|e| {
         SdkError::StrategyParseError(format!("Failed to compile {value} as a numeric value: {e}"))
     })
 }
 
-fn date(node: Pair<Rule>) -> Result<DateTime<Utc>, SdkError> {
+fn date(node: Pair<Rule>) -> CompileResult<DateTime<Utc>> {
     let value = node.as_str();
     value.parse::<DateTime<Utc>>().map_err(|e| {
         SdkError::StrategyParseError(format!("Failed to compile {value} as a date value: {e}"))

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -617,14 +617,14 @@ fn eval(expression: Pairs<Rule>) -> CompileResult<RuleFragment> {
         })
         .map_infix(|lhs, op, rhs| match op.as_rule() {
             Rule::and => Ok(Box::new({
-                let lhs = lhs.unwrap();
-                let rhs = rhs.unwrap();
+                let lhs = lhs?;
+                let rhs = rhs?;
 
                 move |context: &Context| -> bool { lhs(context) && rhs(context) }
             })),
             Rule::or => Ok(Box::new({
-                let lhs = lhs.unwrap();
-                let rhs = rhs.unwrap();
+                let lhs = lhs?;
+                let rhs = rhs?;
 
                 move |context: &Context| -> bool { lhs(context) || rhs(context) }
             })),

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -53,9 +53,13 @@ fn drain<const N: usize>(node: Pairs<Rule>) -> [Pair<Rule>; N] {
 fn drain_partial<const N: usize>(mut node: Pairs<Rule>) -> ([Pair<Rule>; N], Pairs<Rule>) {
     let mut results = vec![];
     for _ in 0..N {
-        results.push(node.next().unwrap());
+        results.push(node.next().expect(&format!(
+            "Expected at least {N} elements when parsing the following pairs {node:?}"
+        )));
     }
-    let array: [Pair<Rule>; N] = results.try_into().unwrap();
+    let array: [Pair<Rule>; N] = results.try_into().expect(&format!(
+        "Expected exactly {N} elements when parsing the following pairs {node:?}"
+    ));
     (array, node)
 }
 


### PR DESCRIPTION
This builds on the work in #121, to completely eliminate the unwrapping code and replaces it with an error handling pattern that allows non compilable rules to yield an error result rather than panic.

Now any node handling function that could previously panic, will now yield a Result<T, SdkError>