### PR TITLE
chore: dotnet target netstandard2

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -30,6 +30,12 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libc6-dev
 
+      - name: Verify libdl installation
+        run: ls -la /usr/lib/x86_64-linux-gnu/libdl.so
+
+      - name: Set up environment variables
+        run: echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)
       - name: Install rust

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -31,10 +31,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libc6-dev
 
       - name: Verify libdl installation
-        run: ls -la /usr/lib/x86_64-linux-gnu/libdl.so
+        run: |
+          find /usr -name "libdl.so*" -exec ls -la {} \;
 
       - name: Set up environment variables
-        run: echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        run: |
+          LIBDL_PATH=$(find /usr -name "libdl.so*" -exec dirname {} \; | head -n 1)
+          echo "LD_LIBRARY_PATH=$LIBDL_PATH:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "Library path set to: $LIBDL_PATH"
 
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)
       - name: Install rust

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -30,15 +30,17 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libc6-dev
 
+      - name: Create symlink for libdl
+        run: |
+          sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+
       - name: Verify libdl installation
         run: |
-          find /usr -name "libdl.so*" -exec ls -la {} \;
+          ls -la /usr/lib/x86_64-linux-gnu/libdl.so
 
       - name: Set up environment variables
         run: |
-          LIBDL_PATH=$(find /usr -name "libdl.so*" -exec dirname {} \; | head -n 1)
-          echo "LD_LIBRARY_PATH=$LIBDL_PATH:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "Library path set to: $LIBDL_PATH"
+          echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libc6-dev
+
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)
       - name: Install rust

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -27,20 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libc6-dev
-
-      - name: Create symlink for libdl
-        run: |
-          sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
-
-      - name: Verify libdl installation
-        run: |
-          ls -la /usr/lib/x86_64-linux-gnu/libdl.so
-
-      - name: Set up environment variables
-        run: |
-          echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       ## snatched from build-java.yml
       ## begin build yggdrasil (maybe this can be a separate job)

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -42,50 +42,50 @@ internal static class FFI
     static FFI()
     {
         string dllPath = GetLibraryPath();
-        IntPtr libHandle = NativeLibrary.Load(dllPath);
+        IntPtr libHandle = NativeLibraryHelper.Load(dllPath);
 
         _newEngine = Marshal.GetDelegateForFunctionPointer<NewEngineDelegate>(
-            NativeLibrary.GetExport(libHandle, "new_engine")
+            NativeLibraryHelper.GetExport(libHandle, "new_engine")
         );
 
         _freeEngine = Marshal.GetDelegateForFunctionPointer<FreeEngineDelegate>(
-            NativeLibrary.GetExport(libHandle, "free_engine")
+            NativeLibraryHelper.GetExport(libHandle, "free_engine")
         );
 
         _getMetrics = Marshal.GetDelegateForFunctionPointer<GetMetricsDelegate>(
-            NativeLibrary.GetExport(libHandle, "get_metrics")
+            NativeLibraryHelper.GetExport(libHandle, "get_metrics")
         );
 
         _take_state = Marshal.GetDelegateForFunctionPointer<TakeStateDelegate>(
-            NativeLibrary.GetExport(libHandle, "take_state")
+            NativeLibraryHelper.GetExport(libHandle, "take_state")
         );
 
         _check_enabled = Marshal.GetDelegateForFunctionPointer<CheckEnabledDelegate>(
-            NativeLibrary.GetExport(libHandle, "check_enabled")
+            NativeLibraryHelper.GetExport(libHandle, "check_enabled")
         );
 
         _check_variant = Marshal.GetDelegateForFunctionPointer<CheckVariantDelegate>(
-            NativeLibrary.GetExport(libHandle, "check_variant")
+            NativeLibraryHelper.GetExport(libHandle, "check_variant")
         );
 
         _free_response = Marshal.GetDelegateForFunctionPointer<FreeResponseDelegate>(
-            NativeLibrary.GetExport(libHandle, "free_response")
+            NativeLibraryHelper.GetExport(libHandle, "free_response")
         );
 
         _count_toggle = Marshal.GetDelegateForFunctionPointer<CountToggleDelegate>(
-            NativeLibrary.GetExport(libHandle, "count_toggle")
+            NativeLibraryHelper.GetExport(libHandle, "count_toggle")
         );
 
         _count_variant = Marshal.GetDelegateForFunctionPointer<CountVariantDelegate>(
-            NativeLibrary.GetExport(libHandle, "count_variant")
+            NativeLibraryHelper.GetExport(libHandle, "count_variant")
         );
 
         _should_emit_impression_event = Marshal.GetDelegateForFunctionPointer<ShouldEmitImpressionEventDelegate>(
-            NativeLibrary.GetExport(libHandle, "should_emit_impression_event")
+            NativeLibraryHelper.GetExport(libHandle, "should_emit_impression_event")
         );
 
         _built_in_strategies = Marshal.GetDelegateForFunctionPointer<BuiltInStrategiesDelegate>(
-            NativeLibrary.GetExport(libHandle, "built_in_strategies")
+            NativeLibraryHelper.GetExport(libHandle, "built_in_strategies")
         );
     }
 

--- a/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
@@ -85,7 +85,8 @@ public static class FFIReader
         }
     }
 
-    private static string PtrToStringUTF8(IntPtr nativeUtf8) {
+    private static string PtrToStringUTF8(IntPtr nativeUtf8)
+    {
         int len = 0;
         while (Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
         byte[] buffer = new byte[len];

--- a/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
@@ -85,15 +85,6 @@ public static class FFIReader
         }
     }
 
-    private static string PtrToStringUTF8(IntPtr nativeUtf8)
-    {
-        int len = 0;
-        while (Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
-        byte[] buffer = new byte[len];
-        Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
-        return Encoding.UTF8.GetString(buffer);
-    }
-
     internal static T? ReadResponse<T>(IntPtr ptr)
         where T : class
     {
@@ -104,7 +95,7 @@ public static class FFIReader
 
         try
         {
-            var json = PtrToStringUTF8(ptr);
+            var json = Marshal.PtrToStringAuto(ptr);
 
             var result = json != null ? JsonSerializer.Deserialize<T>(json, options) : null;
 

--- a/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
@@ -1,6 +1,5 @@
 namespace Yggdrasil;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json;
 
 public static class FFIReader

--- a/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFIReader.cs
@@ -1,5 +1,6 @@
 namespace Yggdrasil;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 
 public static class FFIReader
@@ -84,6 +85,14 @@ public static class FFIReader
         }
     }
 
+    private static string PtrToStringUTF8(IntPtr nativeUtf8) {
+        int len = 0;
+        while (Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
+        byte[] buffer = new byte[len];
+        Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
+        return Encoding.UTF8.GetString(buffer);
+    }
+
     internal static T? ReadResponse<T>(IntPtr ptr)
         where T : class
     {
@@ -94,7 +103,7 @@ public static class FFIReader
 
         try
         {
-            var json = Marshal.PtrToStringUTF8(ptr);
+            var json = PtrToStringUTF8(ptr);
 
             var result = json != null ? JsonSerializer.Deserialize<T>(json, options) : null;
 

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -176,7 +176,7 @@ public static class NativeLibraryHelper
 
     public static IntPtr GetExport(IntPtr handle, string name)
     {
-        IntPtr functionPointer = IntPtr.Zero;
+        IntPtr functionPointer;
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -1,0 +1,123 @@
+using System.Runtime.InteropServices;
+
+public static class NativeLibraryHelper
+{
+  public static IntPtr Load(string libraryPath)
+  {
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      return LoadLibraryWindows(libraryPath);
+    }
+    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+    {
+      return LoadLibraryLinux(libraryPath);
+    }
+    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      return LoadLibraryMac(libraryPath);
+    }
+    else
+    {
+      throw new PlatformNotSupportedException();
+    }
+  }
+
+  public static void Free(IntPtr handle)
+  {
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      FreeLibraryWindows(handle);
+    }
+    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+             RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      FreeLibraryUnix(handle);
+    }
+    else
+    {
+      throw new PlatformNotSupportedException();
+    }
+  }
+
+  public static IntPtr GetExport(IntPtr handle, string name)
+  {
+    IntPtr functionPointer;
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      functionPointer = GetProcAddressWindows(handle, name);
+    }
+    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+             RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+    {
+      functionPointer = GetProcAddressUnix(handle, name);
+    }
+    else
+    {
+      throw new PlatformNotSupportedException();
+    }
+
+    if (functionPointer == IntPtr.Zero)
+    {
+      throw new InvalidOperationException($"Failed to get function pointer for {name}");
+    }
+
+    return functionPointer;
+  }
+
+  [DllImport("kernel32", SetLastError = true)]
+  private static extern IntPtr LoadLibraryWindows(string dllToLoad);
+
+  [DllImport("kernel32", SetLastError = true)]
+  private static extern bool FreeLibraryWindows(IntPtr handle);
+
+  [DllImport("kernel32", SetLastError = true)]
+  private static extern IntPtr GetProcAddressWindows(IntPtr hModule, string procedureName);
+
+  [DllImport("libdl", SetLastError = true)]
+  private static extern IntPtr dlopen(string fileName, int flags);
+
+  [DllImport("libdl", SetLastError = true)]
+  private static extern int dlclose(IntPtr handle);
+
+  [DllImport("libdl", SetLastError = true)]
+  private static extern IntPtr dlsym(IntPtr handle, string name);
+
+  [DllImport("libdl", SetLastError = true)]
+  private static extern IntPtr dlerror();
+
+  private static IntPtr LoadLibraryLinux(string dllToLoad)
+  {
+    const int RTLD_NOW = 2;
+    IntPtr handle = dlopen(dllToLoad, RTLD_NOW);
+    if (handle == IntPtr.Zero)
+    {
+      IntPtr errorPtr = dlerror();
+      string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+      throw new InvalidOperationException($"Failed to load library {dllToLoad}: {errorMessage}");
+    }
+    return handle;
+  }
+
+  private static IntPtr LoadLibraryMac(string dllToLoad)
+  {
+    return LoadLibraryLinux(dllToLoad);
+  }
+
+  private static int FreeLibraryUnix(IntPtr handle)
+  {
+    return dlclose(handle);
+  }
+
+  private static IntPtr GetProcAddressUnix(IntPtr handle, string name)
+  {
+    dlerror();
+    IntPtr res = dlsym(handle, name);
+    IntPtr errorPtr = dlerror();
+    if (errorPtr != IntPtr.Zero)
+    {
+      string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+      throw new InvalidOperationException($"Failed to get function pointer for {name}: {errorMessage}");
+    }
+    return res;
+  }
+}

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -49,7 +49,7 @@ static class NativeLibraryLinuxHelper
         if (handle == IntPtr.Zero)
         {
             IntPtr errorPtr = dlerror();
-            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            string errorMessage = Marshal.PtrToStringAuto(errorPtr);
             throw new InvalidOperationException($"Failed to load library {libraryPath}: {errorMessage}");
         }
 
@@ -68,7 +68,7 @@ static class NativeLibraryLinuxHelper
         IntPtr errorPtr = dlerror();
         if (errorPtr != IntPtr.Zero)
         {
-            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            string errorMessage = Marshal.PtrToStringAuto(errorPtr);
             throw new InvalidOperationException($"Failed to get function pointer for {name}: {errorMessage}");
         }
         return res;
@@ -97,7 +97,7 @@ static class NativeLibraryOSXHelper
         if (handle == IntPtr.Zero)
         {
             IntPtr errorPtr = dlerror();
-            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            string errorMessage = Marshal.PtrToStringAuto(errorPtr);
             throw new InvalidOperationException($"Failed to load library {libraryPath}: {errorMessage}");
         }
 
@@ -116,7 +116,7 @@ static class NativeLibraryOSXHelper
         IntPtr errorPtr = dlerror();
         if (errorPtr != IntPtr.Zero)
         {
-            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            string errorMessage = Marshal.PtrToStringAuto(errorPtr);
             throw new InvalidOperationException($"Failed to get function pointer for {name}: {errorMessage}");
         }
         return res;

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -2,122 +2,122 @@ using System.Runtime.InteropServices;
 
 public static class NativeLibraryHelper
 {
-  public static IntPtr Load(string libraryPath)
-  {
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    public static IntPtr Load(string libraryPath)
     {
-      return LoadLibraryWindows(libraryPath);
-    }
-    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-    {
-      return LoadLibraryLinux(libraryPath);
-    }
-    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-    {
-      return LoadLibraryMac(libraryPath);
-    }
-    else
-    {
-      throw new PlatformNotSupportedException();
-    }
-  }
-
-  public static void Free(IntPtr handle)
-  {
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-      FreeLibraryWindows(handle);
-    }
-    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-             RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-    {
-      FreeLibraryUnix(handle);
-    }
-    else
-    {
-      throw new PlatformNotSupportedException();
-    }
-  }
-
-  public static IntPtr GetExport(IntPtr handle, string name)
-  {
-    IntPtr functionPointer;
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-    {
-      functionPointer = GetProcAddressWindows(handle, name);
-    }
-    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-             RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-    {
-      functionPointer = GetProcAddressUnix(handle, name);
-    }
-    else
-    {
-      throw new PlatformNotSupportedException();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return LoadLibraryWindows(libraryPath);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return LoadLibraryLinux(libraryPath);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return LoadLibraryMac(libraryPath);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 
-    if (functionPointer == IntPtr.Zero)
+    public static void Free(IntPtr handle)
     {
-      throw new InvalidOperationException($"Failed to get function pointer for {name}");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            FreeLibraryWindows(handle);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            FreeLibraryUnix(handle);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 
-    return functionPointer;
-  }
-
-  [DllImport("kernel32", SetLastError = true)]
-  private static extern IntPtr LoadLibraryWindows(string dllToLoad);
-
-  [DllImport("kernel32", SetLastError = true)]
-  private static extern bool FreeLibraryWindows(IntPtr handle);
-
-  [DllImport("kernel32", SetLastError = true)]
-  private static extern IntPtr GetProcAddressWindows(IntPtr hModule, string procedureName);
-
-  [DllImport("libdl", SetLastError = true)]
-  private static extern IntPtr dlopen(string fileName, int flags);
-
-  [DllImport("libdl", SetLastError = true)]
-  private static extern int dlclose(IntPtr handle);
-
-  [DllImport("libdl", SetLastError = true)]
-  private static extern IntPtr dlsym(IntPtr handle, string name);
-
-  [DllImport("libdl", SetLastError = true)]
-  private static extern IntPtr dlerror();
-
-  private static IntPtr LoadLibraryLinux(string dllToLoad)
-  {
-    const int RTLD_NOW = 2;
-    IntPtr handle = dlopen(dllToLoad, RTLD_NOW);
-    if (handle == IntPtr.Zero)
+    public static IntPtr GetExport(IntPtr handle, string name)
     {
-      IntPtr errorPtr = dlerror();
-      string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
-      throw new InvalidOperationException($"Failed to load library {dllToLoad}: {errorMessage}");
+        IntPtr functionPointer;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            functionPointer = GetProcAddressWindows(handle, name);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            functionPointer = GetProcAddressUnix(handle, name);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        if (functionPointer == IntPtr.Zero)
+        {
+            throw new InvalidOperationException($"Failed to get function pointer for {name}");
+        }
+
+        return functionPointer;
     }
-    return handle;
-  }
 
-  private static IntPtr LoadLibraryMac(string dllToLoad)
-  {
-    return LoadLibraryLinux(dllToLoad);
-  }
+    [DllImport("kernel32", SetLastError = true)]
+    private static extern IntPtr LoadLibraryWindows(string dllToLoad);
 
-  private static int FreeLibraryUnix(IntPtr handle)
-  {
-    return dlclose(handle);
-  }
+    [DllImport("kernel32", SetLastError = true)]
+    private static extern bool FreeLibraryWindows(IntPtr handle);
 
-  private static IntPtr GetProcAddressUnix(IntPtr handle, string name)
-  {
-    dlerror();
-    IntPtr res = dlsym(handle, name);
-    IntPtr errorPtr = dlerror();
-    if (errorPtr != IntPtr.Zero)
+    [DllImport("kernel32", SetLastError = true)]
+    private static extern IntPtr GetProcAddressWindows(IntPtr hModule, string procedureName);
+
+    [DllImport("libdl", SetLastError = true)]
+    private static extern IntPtr dlopen(string fileName, int flags);
+
+    [DllImport("libdl", SetLastError = true)]
+    private static extern int dlclose(IntPtr handle);
+
+    [DllImport("libdl", SetLastError = true)]
+    private static extern IntPtr dlsym(IntPtr handle, string name);
+
+    [DllImport("libdl", SetLastError = true)]
+    private static extern IntPtr dlerror();
+
+    private static IntPtr LoadLibraryLinux(string dllToLoad)
     {
-      string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
-      throw new InvalidOperationException($"Failed to get function pointer for {name}: {errorMessage}");
+        const int RTLD_NOW = 2;
+        IntPtr handle = dlopen(dllToLoad, RTLD_NOW);
+        if (handle == IntPtr.Zero)
+        {
+            IntPtr errorPtr = dlerror();
+            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            throw new InvalidOperationException($"Failed to load library {dllToLoad}: {errorMessage}");
+        }
+        return handle;
     }
-    return res;
-  }
+
+    private static IntPtr LoadLibraryMac(string dllToLoad)
+    {
+        return LoadLibraryLinux(dllToLoad);
+    }
+
+    private static int FreeLibraryUnix(IntPtr handle)
+    {
+        return dlclose(handle);
+    }
+
+    private static IntPtr GetProcAddressUnix(IntPtr handle, string name)
+    {
+        dlerror();
+        IntPtr res = dlsym(handle, name);
+        IntPtr errorPtr = dlerror();
+        if (errorPtr != IntPtr.Zero)
+        {
+            string errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            throw new InvalidOperationException($"Failed to get function pointer for {name}: {errorMessage}");
+        }
+        return res;
+    }
 }

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -127,7 +127,7 @@ public static class NativeLibraryHelper
 {
     public static IntPtr Load(string libraryPath)
     {
-        IntPtr handle = IntPtr.Zero;
+        IntPtr handle;
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLibraryHelper.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 
-static class NativeLibraryWindowsHelper {
+static class NativeLibraryWindowsHelper
+{
     [DllImport("kernel32", SetLastError = true)]
     private static extern IntPtr LoadLibraryWindows(string dllToLoad);
 
@@ -10,20 +11,24 @@ static class NativeLibraryWindowsHelper {
     [DllImport("kernel32", SetLastError = true)]
     private static extern IntPtr GetProcAddressWindows(IntPtr hModule, string procedureName);
 
-    public static IntPtr Load(string libraryPath) {
+    public static IntPtr Load(string libraryPath)
+    {
         return LoadLibraryWindows(libraryPath);
     }
 
-    public static void Free(IntPtr handle) {
+    public static void Free(IntPtr handle)
+    {
         FreeLibraryWindows(handle);
     }
 
-    public static IntPtr GetExport(IntPtr handle, string name) {
+    public static IntPtr GetExport(IntPtr handle, string name)
+    {
         return GetProcAddressWindows(handle, name);
     }
 }
 
-static class NativeLibraryLinuxHelper {
+static class NativeLibraryLinuxHelper
+{
     [DllImport("libdl.so.2", SetLastError = true)]
     private static extern IntPtr dlopen(string fileName, int flags);
 
@@ -70,7 +75,8 @@ static class NativeLibraryLinuxHelper {
     }
 }
 
-static class NativeLibraryOSXHelper {
+static class NativeLibraryOSXHelper
+{
     [DllImport("libc.dylib", SetLastError = true)]
     private static extern IntPtr dlopen(string fileName, int flags);
 

--- a/dotnet-engine/Yggdrasil.Engine/Strategies.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Strategies.cs
@@ -66,14 +66,10 @@ internal class CustomStrategies
             return "{}";
         }
 
-        var strategies = new Dictionary<string, bool>(
-        feature.Strategies
-            .Where(strategy => strategy.IsEnabled(context))
-            .Select(strategy =>
-                new KeyValuePair<string, bool>(
-                    strategy.ResultName,
-                    strategy.IsEnabled(context)))
-            .ToList());
+        var strategies = feature.Strategies
+            .ToDictionary(strategy => strategy.ResultName,
+                strategy => strategy.IsEnabled(context));
+
         return JsonSerializer.Serialize(strategies, options);
     }
 }

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -60,7 +60,7 @@ public class Payload
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Value, PayloadType);
+        return new { Value, PayloadType }.GetHashCode();
     }
 }
 

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Yggdrasil.Engine</PackageId>
@@ -11,6 +12,10 @@
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+  </ItemGroup>
 
   <Target Name="YggdrasilPreBuild" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug'">
     <Exec Command="


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2342/change-engine-target-to-net-standard-20

After doing some reading, shouldn't we aim to target [.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0) instead of .NET 6.0 specifically?

Seems like this has the most compatibility / possible target surface currently.

I needed to make a few changes to make this work, due to missing APIs.

Out of curiosity, is there any specific reason we're targeting .NET 6.0 in our tests? Should we keep it for now?