### PR TITLE
docs: dotnet mention .NET 6.0 runtime

### DIFF
--- a/dotnet-engine/README.md
+++ b/dotnet-engine/README.md
@@ -16,6 +16,8 @@ dotnet build
 
 ## Running the tests
 
+The current target is .NET 6.0, so in order to run the tests you should have the respective runtime installed: https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime
+
 ```bash
 dotnet test
 ```


### PR DESCRIPTION
Add mention of .NET 6.0 runtime for running tests.