### PR TITLE
chore: warning cleanups

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -466,8 +466,7 @@ impl EngineState {
         }
         let total_weight: u32 = variants.iter().map(|var| var.weight as u32).sum();
 
-        let stickiness = variants
-            .get(0)
+        let stickiness = variants.first()
             .and_then(|variant| variant.stickiness.clone());
 
         let target = get_seed(stickiness, context)

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -1140,7 +1140,7 @@ mod tests {
         expected_value: bool,
     ) {
         let constraint_ips = constraint_ips
-            .split(",")
+            .split(',')
             .map(|x| format!("\"{}\"", x.trim()))
             .collect::<Vec<String>>();
 

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -15,6 +15,9 @@ enum StrategyType {
     FlexibleRollout,
     RemoteAddress,
     ApplicationHostname,
+    //This is a catch all handler on the enum type because we don't know what the
+    // custom strategy will be called ahead of time
+    #[allow(dead_code)]
     Custom(String),
 }
 
@@ -31,7 +34,7 @@ impl IsCustom for Strategy {
     }
 }
 
-pub fn upgrade(strategies: &Vec<Strategy>, segment_map: &HashMap<i32, Segment>) -> String {
+pub fn upgrade(strategies: &[Strategy], segment_map: &HashMap<i32, Segment>) -> String {
     if strategies.is_empty() {
         return "true".into();
     }

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -51,7 +51,7 @@ impl<T> From<Result<Option<T>, FFIError>> for Response<T> {
 enum FFIError {
     Utf8Error,
     InvalidJson,
-    NullError(String),
+    NullError,
 }
 
 const KNOWN_STRATEGIES: [&str; 8] = [
@@ -79,7 +79,7 @@ impl From<serde_json::Error> for FFIError {
 
 unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState, FFIError> {
     if engine_ptr.is_null() {
-        Err(FFIError::NullError("Null engine pointer".into()))
+        Err(FFIError::NullError)
     } else {
         Ok(unsafe { &mut *(engine_ptr as *mut EngineState) })
     }
@@ -87,7 +87,7 @@ unsafe fn get_engine<'a>(engine_ptr: *mut c_void) -> Result<&'a mut EngineState,
 
 unsafe fn get_str<'a>(ptr: *const c_char) -> Result<&'a str, FFIError> {
     if ptr.is_null() {
-        Err(FFIError::NullError("Null pointer".into()))
+        Err(FFIError::NullError)
     } else {
         unsafe { CStr::from_ptr(ptr).to_str().map_err(FFIError::from) }
     }


### PR DESCRIPTION
Silly cleanups, mostly trimming out dead code

There's one warning which we now suppress, this one is subtle but important - it allows us to identify custom strategies without treating it as an active edge case (makes the code a bit simpler to have that in place). Wouldn't be a warning if the whole stack was pure Rust but it isn't