### PR TITLE
fix: .NET variant constructor arg names

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -33,8 +33,8 @@ public class Variant
     {
         Name = name;
         Payload = payload;
-        IsEnabled = enabled;
-        FeatureEnabled = feature_enabled;
+        Enabled = enabled;
+        Feature_Enabled = feature_enabled;
     }
 
     public static readonly Variant DISABLED_VARIANT = new Variant("disabled", null, false, false);
@@ -42,9 +42,9 @@ public class Variant
     public string Name { get; set; }
     public Payload? Payload { get; set; }
     [JsonPropertyName("enabled")]
-    public bool IsEnabled { get; set; }
+    public bool Enabled { get; set; }
     [JsonPropertyName("feature_enabled")]
-    public bool FeatureEnabled { get; set; }
+    public bool Feature_Enabled { get; set; }
 }
 
 public class Payload

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -29,12 +29,12 @@ public class EngineResponse<TValue> : EngineResponse
 
 public class Variant
 {
-    public Variant(string name, Payload? payload, bool isEnabled, bool featureEnabled)
+    public Variant(string name, Payload? payload, bool enabled, bool feature_enabled)
     {
         Name = name;
         Payload = payload;
-        IsEnabled = isEnabled;
-        FeatureEnabled = featureEnabled;
+        IsEnabled = enabled;
+        FeatureEnabled = feature_enabled;
     }
 
     public static readonly Variant DISABLED_VARIANT = new Variant("disabled", null, false, false);

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <Target Name="YggdrasilPreBuild" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
It seems like, in .NET, constructor argument names are taken into consideration when (de)serializing. This is something we stumbled upon in https://github.com/Unleash/unleash-client-dotnet/pull/224 and something that will probably bite us again later down the line.

It seems like:
 - Newtonsoft.Json wants constructor arg names to match the JSON properties;
 - System.Text.Json wants the class properties to match the constructor arg names;

This PR makes it so the Variant constructor arg names align with https://github.com/Unleash/unleash-client-dotnet/blob/main/src/Unleash/Internal/Variant.cs#L9 and then adapts the properties to match the new constructor arg names.

This change should hopefully make both serializers happy, since we support both in our .NET SDK.

This should also make it easier for us to drop `Variant.cs` in `unleash-client-dotnet` later down the line, and just rely on Yggdrasil's Variant instead, like https://github.com/Unleash/unleash-client-dotnet/pull/232