### PR TITLE
feat: make go work with updated FFI

### DIFF
--- a/go-engine/go.mod
+++ b/go-engine/go.mod
@@ -1,3 +1,3 @@
 module github.com/sighphyre/yggdrasil/go-engine
 
-go 1.17
+go 1.18

--- a/go-engine/unleash_engine_test.go
+++ b/go-engine/unleash_engine_test.go
@@ -86,8 +86,9 @@ func TestGetVariant(t *testing.T) {
 	)
 
 	variant := engine.GetVariant("Feature.A", context)
+
 	if variant == nil {
-		t.Fatalf("Feature.A should have variant")
+		variant = &VariantDef{"disabled", nil, false, engine.IsEnabled("Feature.A", context)}
 	}
 	if variant.Name != "disabled" {
 		t.Fatalf("Feature.A should have been disabled")
@@ -211,6 +212,10 @@ func TestClientSpecification(t *testing.T) {
 				)
 
 				result := engine.GetVariant(toggleName, context)
+
+				if result == nil {
+					result = &VariantDef{"disabled", nil, false, false}
+				}
 
 				jsonExpectedResult, _ := json.Marshal(expectedResult)
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This updates the FFI implementation of the Go code. This was outdated and was no longer working. I updated the minimum golang to 1.18 in order to use generics.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
- I simply use an empty object for the custom strategy (this is also now deprecated in Unleash, right?). This was also done for `getVariant` in Java
- This part (in tests) I copied from a Java test case:
```golang
 if variant == nil {
    variant = &VariantDef{"disabled", nil, false, engine.IsEnabled("Feature.A", context)}
}
```
