### PR TITLE
chore: make wasm build again

### DIFF
--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -37,4 +37,6 @@ jobs:
         uses: jetli/wasm-pack-action@v0.3.0
 
       - name: Build WASM
-        run: wasm-pack build --target nodejs
+        run: |
+          cd wasm-engine
+          wasm-pack build --target nodejs

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -53,4 +53,4 @@ jobs:
           path: client-specification
       - name: Run tests
         run: |
-          cargo test
+          cargo test --all-features

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -20,10 +20,8 @@ convert_case = "0.6.0"
 unleash-types = "0.13.0"
 chrono = "0.4.38"
 dashmap = "5.5.0"
+hostname = { version = "0.3.1", optional = true }
 ipnetwork = "0.20.0"
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-hostname = "0.3.1"
 
 [dependencies.serde]
 features = ["derive"]

--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -20,8 +20,10 @@ convert_case = "0.6.0"
 unleash-types = "0.13.0"
 chrono = "0.4.38"
 dashmap = "5.5.0"
-hostname = "0.3.1"
 ipnetwork = "0.20.0"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+hostname = "0.3.1"
 
 [dependencies.serde]
 features = ["derive"]

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -1,8 +1,6 @@
 extern crate pest;
 
 use std::collections::HashSet;
-#[cfg(feature = "hostname")]
-use std::env;
 use std::io::Cursor;
 use std::net::IpAddr;
 use std::num::ParseFloatError;
@@ -12,8 +10,6 @@ use crate::sendable_closures::{SendableContextResolver, SendableFragment};
 use crate::state::SdkError;
 use crate::EnrichedContext as Context;
 use chrono::{DateTime, Utc};
-#[cfg(feature = "hostname")]
-use hostname;
 use ipnetwork::{IpNetwork, IpNetworkError};
 use murmur3::murmur3_32;
 use pest::iterators::{Pair, Pairs};
@@ -21,6 +17,11 @@ use pest::pratt_parser::{Assoc, Op, PrattParser};
 use pest::Parser;
 use rand::Rng;
 use semver::Version;
+
+#[cfg(feature = "hostname")]
+use std::env;
+#[cfg(feature = "hostname")]
+use hostname;
 
 #[derive(Parser)]
 #[grammar = "strategy_grammar.pest"]

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -1,7 +1,6 @@
 extern crate pest;
 
 use std::collections::HashSet;
-use std::env;
 use std::io::Cursor;
 use std::net::IpAddr;
 use std::num::ParseFloatError;
@@ -11,7 +10,7 @@ use crate::sendable_closures::{SendableContextResolver, SendableFragment};
 use crate::state::SdkError;
 use crate::EnrichedContext as Context;
 use chrono::{DateTime, Utc};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "hostname")]
 use hostname;
 use ipnetwork::{IpNetwork, IpNetworkError};
 use murmur3::murmur3_32;
@@ -400,7 +399,7 @@ fn rollout_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {
     }))
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "hostname")]
 fn get_hostname() -> CompileResult<String> {
     //This is primarily for testing purposes
     if let Ok(hostname_env) = env::var("hostname") {
@@ -416,7 +415,7 @@ fn get_hostname() -> CompileResult<String> {
         })
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "hostname"))]
 fn get_hostname() -> CompileResult<String> {
     Err(SdkError::StrategyParseError("Hostname is not supported on this platform".into()))
 }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -11,6 +11,7 @@ use crate::sendable_closures::{SendableContextResolver, SendableFragment};
 use crate::state::SdkError;
 use crate::EnrichedContext as Context;
 use chrono::{DateTime, Utc};
+#[cfg(not(target_family = "wasm"))]
 use hostname;
 use ipnetwork::{IpNetwork, IpNetworkError};
 use murmur3::murmur3_32;
@@ -399,6 +400,7 @@ fn rollout_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {
     }))
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn get_hostname() -> CompileResult<String> {
     //This is primarily for testing purposes
     if let Ok(hostname_env) = env::var("hostname") {
@@ -412,6 +414,11 @@ fn get_hostname() -> CompileResult<String> {
                 .into_string()
                 .map_err(|_| SdkError::StrategyEvaluationError)
         })
+}
+
+#[cfg(target_family = "wasm")]
+fn get_hostname() -> CompileResult<String> {
+    Err(SdkError::StrategyParseError("Hostname is not supported on this platform".into()))
 }
 
 fn hostname_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -1,6 +1,8 @@
 extern crate pest;
 
 use std::collections::HashSet;
+#[cfg(feature = "hostname")]
+use std::env;
 use std::io::Cursor;
 use std::net::IpAddr;
 use std::num::ParseFloatError;
@@ -1072,37 +1074,42 @@ mod tests {
         assert!(rule(&context));
     }
 
-    #[test]
-    fn evaluates_host_name_constraint_correctly() {
-        std::env::set_var("hostname", "DOS");
+    #[cfg(feature = "hostname")]
+    mod hostname_tests {
+      use super::*;
+    
+      #[test]
+      fn evaluates_host_name_constraint_correctly() {
+          std::env::set_var("hostname", "DOS");
 
-        let rule = compile_rule("hostname in [\"DOS\"]").unwrap();
-        let context = Context::default();
-        assert!(rule(&context));
+          let rule = compile_rule("hostname in [\"DOS\"]").unwrap();
+          let context = Context::default();
+          assert!(rule(&context));
 
-        std::env::remove_var("hostname");
-    }
+          std::env::remove_var("hostname");
+      }
 
-    #[test]
-    fn evaluates_host_name_to_false_when_missing_hostname_values() {
-        std::env::set_var("hostname", "DOS");
+      #[test]
+      fn evaluates_host_name_to_false_when_missing_hostname_values() {
+          std::env::set_var("hostname", "DOS");
 
-        let rule = compile_rule("hostname in [\"\"]").unwrap();
-        let context = Context::default();
-        assert!(!rule(&context));
+          let rule = compile_rule("hostname in [\"\"]").unwrap();
+          let context = Context::default();
+          assert!(!rule(&context));
 
-        std::env::remove_var("hostname");
-    }
+          std::env::remove_var("hostname");
+      }
 
-    #[test]
-    fn hostname_constraint_ignores_casing() {
-        std::env::set_var("hostname", "DaRWin");
+      #[test]
+      fn hostname_constraint_ignores_casing() {
+          std::env::set_var("hostname", "DaRWin");
 
-        let rule = compile_rule("hostname in [\"dArWin\", \"pop-os\"]").unwrap();
-        let context = Context::default();
-        assert!(rule(&context));
+          let rule = compile_rule("hostname in [\"dArWin\", \"pop-os\"]").unwrap();
+          let context = Context::default();
+          assert!(rule(&context));
 
-        std::env::remove_var("hostname");
+          std::env::remove_var("hostname");
+      }
     }
 
     #[test_case("127.0.0.1", "127.0.0.1", true; "Exact match")]

--- a/wasm-engine/README.md
+++ b/wasm-engine/README.md
@@ -19,7 +19,7 @@ $ yarn add @unleash/yggdrasil-engine
 Then, you can use it in your code:
 
 ```js
-  const yggdrasil = require("../pkg/wasm_engine.js");
+  const yggdrasil = require("../pkg/yggdrasil_engine.js");
 
   const context = {
     userId: "7",

--- a/wasm-engine/e2e-tests/wasm-engine.test.js
+++ b/wasm-engine/e2e-tests/wasm-engine.test.js
@@ -1,4 +1,4 @@
-const yggdrasil = require("../pkg/wasm_engine.js");
+const yggdrasil = require("../pkg/yggdrasil_engine.js");
 
 test("Rule evaluates correctly", () => {
   const context = {

--- a/wasm-engine/tests/web.rs
+++ b/wasm-engine/tests/web.rs
@@ -1,12 +1,12 @@
 //! Test suite for the Web and headless browsers.
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(target_family = "wasm")]
 
 extern crate wasm_bindgen_test;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
-use wasm_engine::{evaluate, Context};
+use yggdrasil_engine::{evaluate, Context};
 
 #[wasm_bindgen_test]
 fn dsl_evaluates_correct() {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2630/make-yggdrasil-wasm-build-again

Makes WASM build again by fixing some references and handling `hostname`, since it's not WASM-compatible.

**Question**: We're currently not running tests as part of our actions. Maybe we should?

![image](https://github.com/user-attachments/assets/521caf53-7e4d-4f34-b0dd-d9f5c7749491)

![image](https://github.com/user-attachments/assets/a8d06773-9df6-4b7a-b0f8-a08b3d90ecdc)