### PR TITLE
fix: makes random distribution better distributed

### DIFF
--- a/unleash-yggdrasil/src/strategy_grammar.pest
+++ b/unleash-yggdrasil/src/strategy_grammar.pest
@@ -1,5 +1,5 @@
 num = @{ int ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ int)? }
-    int = { ("+" | "-")? ~ ASCII_DIGIT+ }
+int = { ("+" | "-")? ~ ASCII_DIGIT+ }
 
 percentage = { ("100" | (ASCII_DIGIT ~ ASCII_DIGIT?)) ~ "%" }
 
@@ -29,7 +29,7 @@ semver_list = { "[" ~ semver ~ ( "," ~ semver )* ~ "]" }
 WHITESPACE = _{ " " | "\t" }
 NULL_COALESCE = _{ "|" }
 
-random = { "random" }
+random = { "random[" ~ int ~ "]" | "random" }
 
 boolean_operation = _{ and | or }
     and     = { "and" }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -4,7 +4,8 @@ use unleash_types::client_features::{Constraint, Operator, Segment, Strategy, St
 
 use crate::state::SdkError;
 
-const DEFAULT_STICKINESS: &str = "user_id | session_id | random";
+const DEFAULT_STICKINESS: &str = "user_id | session_id | random[10000]";
+const DEFAULT_RANDOM: &str = "random[10000]";
 
 enum StrategyType {
     Default,
@@ -386,7 +387,7 @@ fn upgrade_operator(op: &Operator, case_insensitive: bool) -> Option<String> {
 fn upgrade_stickiness(stickiness_param: Option<&String>) -> String {
     if let Some(stickiness_param) = stickiness_param {
         match stickiness_param.as_ref() {
-            "random" => "random".into(),
+            "random" => DEFAULT_RANDOM.into(),
             "default" => DEFAULT_STICKINESS.into(),
             _ => upgrade_context_name(stickiness_param),
         }
@@ -637,7 +638,7 @@ mod tests {
         let output = upgrade(&vec![strategy], &HashMap::new());
         assert_eq!(
             output.as_str(),
-            "55% sticky on user_id | session_id | random with group_id of \"Feature.flexibleRollout.userId.55\""
+            "55% sticky on user_id | session_id | random[10000] with group_id of \"Feature.flexibleRollout.userId.55\""
         );
     }
 
@@ -659,7 +660,7 @@ mod tests {
         let output = upgrade(&vec![strategy], &HashMap::new());
         assert_eq!(
             output.as_str(),
-            "55% sticky on user_id | session_id | random"
+            "55% sticky on user_id | session_id | random[10000]"
         );
     }
 
@@ -684,7 +685,7 @@ mod tests {
         assert_eq!(
             output.as_str(),
             format!(
-                "55% sticky on user_id | session_id | random with group_id of \"Feature.flexibleRollout.userId.55\""
+                "55% sticky on user_id | session_id | random[10000] with group_id of \"Feature.flexibleRollout.userId.55\""
             )
         );
     }
@@ -709,7 +710,7 @@ mod tests {
         let output = upgrade(&vec![strategy], &HashMap::new());
         assert_eq!(
             output.as_str(),
-            format!("55% sticky on random with group_id of \"Feature.flexibleRollout.userId.55\"")
+            format!("55% sticky on random[10000] with group_id of \"Feature.flexibleRollout.userId.55\"")
         );
     }
 


### PR DESCRIPTION
This adds a way to parametize random in the grammar so that you can do things like this "random[1000]" which will create an expression of a random number bounded by 0, 1000. Default stickiness and explicitly random flexible rollouts will now use random[10000] instead of random (previously defaulting to 100), which gives random strategies better statistical distribution 