### PR TITLE
chore: 0.0.5 of the ruby engine

### DIFF
--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '0.0.5.beta.19'
+  s.version = '0.0.5'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'


### PR DESCRIPTION
Just because doing an actual release with a beta dependency feels icky. It's time to let this thing out into the wide world