### PR TITLE
chore: fix feature enabled

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -29,22 +29,20 @@ public class EngineResponse<TValue> : EngineResponse
 
 public class Variant
 {
-    public Variant(string name, Payload? payload, bool enabled, bool feature_enabled)
+    public Variant(string name, Payload? payload, bool enabled, bool featureEnabled)
     {
         Name = name;
         Payload = payload;
         Enabled = enabled;
-        Feature_Enabled = feature_enabled;
+        FeatureEnabled = featureEnabled;
     }
 
     public static readonly Variant DISABLED_VARIANT = new Variant("disabled", null, false, false);
 
     public string Name { get; set; }
     public Payload? Payload { get; set; }
-    [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }
-    [JsonPropertyName("feature_enabled")]
-    public bool Feature_Enabled { get; set; }
+    public bool FeatureEnabled { get; set; }
 }
 
 public class Payload
@@ -115,7 +113,7 @@ public class MetricsBucket
 public interface IStrategy
 {
     /// <summary>
-    /// Gets the stragegy name 
+    /// Gets the stragegy name
     /// </summary>
     string Name { get; }
 

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.0-beta.0</Version>
+    <Version>1.0.0-beta.1</Version>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>
     <IncludeSymbols>True</IncludeSymbols>
@@ -21,12 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <Target Name="YggdrasilPreBuild" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug'">
     <Exec Command="
-      cd ../../ 
+      cd ../../
       cargo build --release" />
   </Target>
 


### PR DESCRIPTION
Yggdrasil core has moved on from "feature_enabled" to featureEnabled. That's not publicly exposed in Edge and the SDKs can deal with it on their own terms while we migrate forward to a consistent casing scheme.

Because this affects the JSON serialising, this affects consuming SDKs as well, in practice that's just Ruby and .NET. Ruby doesn't need a patch because it already uses snake casing conversions. This brings .NET to the table