### PR TITLE
chore: add autoformatting config

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -1,1 +1,119 @@
 
+name: Build Release Binaries
+
+on:
+  push:
+    tags:
+      - unleash-yggdrasil-*
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "The tag name for the release to upload binaries to, e.g. unleash-yggdrasil-v0.13.3"
+        required: true
+
+jobs:
+  build-binaries:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            output: libyggdrasilffi.so
+            name: libyggdrasilffi_x86_64.so
+            cross: false
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            output: libyggdrasilffi.so
+            name: libyggdrasilffi_arm64.so
+            cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            output: libyggdrasilffi.so
+            name: libyggdrasilffi_aarch64.so
+            cross: true
+          - os: windows-latest
+            target: x86_64-pc-windows-gnu
+            output: yggdrasilffi.dll
+            name: libyggdrasilffi_x86_64.dll
+            cross: false
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            output: yggdrasilffi.dll
+            name: libyggdrasilffi_arm64.dll
+            cross: false
+          - os: macos-13
+            target: x86_64-apple-darwin
+            output: libyggdrasilffi.dylib
+            name: libyggdrasilffi_x86_64.dylib
+            cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            output: libyggdrasilffi.dylib
+            name: libyggdrasilffi_arm64.dylib
+            cross: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install cross (if needed)
+      if: ${{ matrix.cross == true }}
+      run: cargo install cross
+
+    - name: Install rust
+      run: |
+        rustup set auto-self-update disable
+        rustup toolchain install stable --profile default
+        rustup show
+
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Build Rust Library (Cross)
+      if: ${{ matrix.cross == true }}
+      run: cross build -p yggdrasilffi --release --target ${{ matrix.target }};
+
+    - name: Build Rust Library (Cargo)
+      if: ${{ matrix.cross == false }}
+      run: cargo build -p yggdrasilffi --release --target ${{ matrix.target }};
+
+    - name: Rename Output Binary
+      run: |
+        mv target/${{ matrix.target }}/release/${{ matrix.output }} target/${{ matrix.target }}/release/${{ matrix.name }}
+
+    - name: Set Tag Name
+      id: set_tag_name
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "tag=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
+        else
+          echo "tag=${{ github.ref }}" | sed 's|refs/tags/||' >> $GITHUB_ENV
+        fi
+
+    - name: Get Release by Tag
+      id: get_release
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const tag = process.env.tag;
+          const { data: releases } = await github.rest.repos.listReleases({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const release = releases.find(r => r.tag_name === tag);
+          if (release) {
+            return { release_id: release.id };
+          } else {
+            throw new Error(`Release with tag ${tag} not found.`);
+          }
+        result-encoding: json
+
+    - name: Upload Binary to Release
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.get_release.outputs.release_id }}
+        asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
+        asset_name: "${{ matrix.name }}"
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -41,7 +41,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             output: yggdrasilffi.dll
             name: libyggdrasilffi_arm64.dll
-            cross: false
+            cross: true
           - os: macos-13
             target: x86_64-apple-darwin
             output: libyggdrasilffi.dylib
@@ -71,7 +71,9 @@ jobs:
 
     - name: Build Rust Library (Cross)
       if: ${{ matrix.cross == true }}
-      run: cross build -p yggdrasilffi --release --target ${{ matrix.target }};
+      run: |
+        rustup target add aarch64-pc-windows-msvc
+        cross build -p yggdrasilffi --release --target ${{ matrix.target }};
 
     - name: Build Rust Library (Cargo)
       if: ${{ matrix.cross == false }}
@@ -81,8 +83,9 @@ jobs:
       run: |
         mv target/${{ matrix.target }}/release/${{ matrix.output }} target/${{ matrix.target }}/release/${{ matrix.name }}
 
-    - name: Set Tag Name
-      id: set_tag_name
+    - name: Set Tag Name on Linux/Mac
+      if: runner.os != 'Windows'
+      id: set_tag_name_unix
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           echo "tag=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
@@ -90,28 +93,43 @@ jobs:
           echo "tag=${{ github.ref }}" | sed 's|refs/tags/||' >> $GITHUB_ENV
         fi
 
-    - name: Get Release by Tag
+    - name: Set Tag Name on Windows
+      if: runner.os == 'Windows'
+      id: set_tag_name_win
+      shell: pwsh
+      run: |
+        if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+          echo "tag=${{ github.event.inputs.release_tag }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+        else {
+          $tag = $env:GITHUB_REF -replace 'refs/tags/', ''
+          echo "tag=$tag" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+
+    - name: Get Release Upload URL by Tag
       id: get_release
       uses: actions/github-script@v5
       with:
         script: |
           const tag = process.env.tag;
+          console.log(`Looking for release with tag: ${tag}`);
           const { data: releases } = await github.rest.repos.listReleases({
             owner: context.repo.owner,
             repo: context.repo.repo,
           });
           const release = releases.find(r => r.tag_name === tag);
           if (release) {
-            return { release_id: release.id };
+            core.setOutput("upload_url", release.upload_url);
           } else {
             throw new Error(`Release with tag ${tag} not found.`);
           }
         result-encoding: json
 
     - name: Upload Binary to Release
+      if: ${{ steps.get_release.outputs.upload_url }}
       uses: actions/upload-release-asset@v1
       with:
-        upload_url: ${{ steps.get_release.outputs.release_id }}
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
         asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
         asset_name: "${{ matrix.name }}"
         asset_content_type: application/octet-stream

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install required cargo packages for reporting format
         run: cargo install clippy-sarif sarif-fmt
+      - name: Check formatting
+        run: cargo fmt -- --check
       - name: Run rust-clippy
         run: |
           cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -466,7 +466,8 @@ impl EngineState {
         }
         let total_weight: u32 = variants.iter().map(|var| var.weight as u32).sum();
 
-        let stickiness = variants.first()
+        let stickiness = variants
+            .first()
             .and_then(|variant| variant.stickiness.clone());
 
         let target = get_seed(stickiness, context)
@@ -532,7 +533,7 @@ impl EngineState {
         self.get_toggle(name).map(|toggle| {
             if self.enabled(toggle, context, external_values) {
                 self.check_variant_by_toggle(toggle, context)
-                        .unwrap_or_default()
+                    .unwrap_or_default()
             } else {
                 VariantDef::default()
             }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -381,7 +381,6 @@ fn rollout_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {
 
     Ok(Box::new(move |context: &Context| {
         if let Some(stickiness) = stickiness_resolver(context) {
-
             let group_id = match &group_id {
                 Some(group_id) => group_id.clone(),
                 None => context.toggle_name.clone(),

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -968,6 +968,9 @@ mod tests {
 
         assert!(compile_rule(&rule).is_ok());
 
-        assert_eq!(rule.as_str(), "user_id in [\"[\\\"123\\\"\",\"\\\"456\\\"\",\"\\\"789\\\"]\"]");
+        assert_eq!(
+            rule.as_str(),
+            "user_id in [\"[\\\"123\\\"\",\"\\\"456\\\"\",\"\\\"789\\\"]\"]"
+        );
     }
 }

--- a/yggdrasilwasm/src/lib.rs
+++ b/yggdrasilwasm/src/lib.rs
@@ -2,10 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::from_value;
-use wasm_bindgen::prelude::*;
-use unleash_yggdrasil::{Context, EngineState, ExtendedVariantDef};
-use unleash_types::client_features::ClientFeatures;
 use std::collections::HashMap;
+use unleash_types::client_features::ClientFeatures;
+use unleash_yggdrasil::{Context, EngineState, ExtendedVariantDef};
+use wasm_bindgen::prelude::*;
 
 type CustomStrategyResults = HashMap<String, bool>;
 
@@ -70,7 +70,12 @@ impl Engine {
     }
 
     #[wasm_bindgen(js_name = checkEnabled)]
-    pub fn check_enabled(&self, toggle_name: &str, context: JsValue, custom_strategy_results: JsValue) -> JsValue {
+    pub fn check_enabled(
+        &self,
+        toggle_name: &str,
+        context: JsValue,
+        custom_strategy_results: JsValue,
+    ) -> JsValue {
         let context: Context = match from_value(context) {
             Ok(ctx) => ctx,
             Err(e) => {
@@ -83,23 +88,26 @@ impl Engine {
             }
         };
 
-        let custom_strategy_results: Option<CustomStrategyResults> = if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
-            None
-        } else {
-            match from_value(custom_strategy_results) {
-                Ok(results) => Some(results),
-                Err(e) => {
-                    let response = Response::<bool> {
-                        status_code: ResponseCode::Error,
-                        value: None,
-                        error_message: Some(format!("Invalid strategy results: {}", e)),
-                    };
-                    return serde_wasm_bindgen::to_value(&response).unwrap();
+        let custom_strategy_results: Option<CustomStrategyResults> =
+                if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
+                None
+            } else {
+                match from_value(custom_strategy_results) {
+                    Ok(results) => Some(results),
+                    Err(e) => {
+                        let response = Response::<bool> {
+                            status_code: ResponseCode::Error,
+                            value: None,
+                            error_message: Some(format!("Invalid strategy results: {}", e)),
+                        };
+                        return serde_wasm_bindgen::to_value(&response).unwrap();
+                    }
                 }
-            }
-        };
+            };
 
-        let check_enabled = self.engine.check_enabled(toggle_name, &context, &custom_strategy_results);
+        let check_enabled =
+            self.engine
+                .check_enabled(toggle_name, &context, &custom_strategy_results);
 
         let response = Response {
             status_code: ResponseCode::Ok,
@@ -111,7 +119,12 @@ impl Engine {
     }
 
     #[wasm_bindgen(js_name = checkVariant)]
-    pub fn check_variant(&self, toggle_name: &str, context: JsValue, custom_strategy_results: JsValue) -> JsValue {
+    pub fn check_variant(
+        &self,
+        toggle_name: &str,
+        context: JsValue,
+        custom_strategy_results: JsValue,
+    ) -> JsValue {
         let context: Context = match from_value(context) {
             Ok(ctx) => ctx,
             Err(e) => {
@@ -124,26 +137,32 @@ impl Engine {
             }
         };
 
-        let custom_strategy_results: Option<CustomStrategyResults> = if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
-            None
-        } else {
-            match from_value(custom_strategy_results) {
-                Ok(results) => Some(results),
-                Err(e) => {
-                    let response = Response::<ExtendedVariantDef> {
-                        status_code: ResponseCode::Error,
-                        value: None,
-                        error_message: Some(format!("Invalid strategy results: {}", e)),
-                    };
-                    return serde_wasm_bindgen::to_value(&response).unwrap();
+        let custom_strategy_results: Option<CustomStrategyResults> =
+            if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
+                None
+            } else {
+                match from_value(custom_strategy_results) {
+                    Ok(results) => Some(results),
+                    Err(e) => {
+                        let response = Response::<ExtendedVariantDef> {
+                            status_code: ResponseCode::Error,
+                            value: None,
+                            error_message: Some(format!("Invalid strategy results: {}", e)),
+                        };
+                        return serde_wasm_bindgen::to_value(&response).unwrap();
+                    }
                 }
-            }
-        };
+            };
 
-        let base_variant = self.engine.check_variant(toggle_name, &context, &custom_strategy_results);
-        let toggle_enabled = self.engine.is_enabled(toggle_name, &context, &custom_strategy_results);
+        let base_variant =
+            self.engine
+                .check_variant(toggle_name, &context, &custom_strategy_results);
+        let toggle_enabled =
+            self.engine
+                .is_enabled(toggle_name, &context, &custom_strategy_results);
 
-        let enriched_variant = base_variant.map(|variant| variant.to_enriched_response(toggle_enabled));
+        let enriched_variant =
+            base_variant.map(|variant| variant.to_enriched_response(toggle_enabled));
 
         let response = Response {
             status_code: ResponseCode::Ok,

--- a/yggdrasilwasm/src/lib.rs
+++ b/yggdrasilwasm/src/lib.rs
@@ -89,7 +89,7 @@ impl Engine {
         };
 
         let custom_strategy_results: Option<CustomStrategyResults> =
-                if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
+            if custom_strategy_results.is_null() || custom_strategy_results.is_undefined() {
                 None
             } else {
                 match from_value(custom_strategy_results) {


### PR DESCRIPTION
Sets up autoformatting

- Adds an empty rustfml.toml file, which should force most tools to use the base config for rustfmt (including cargo)
- Applies that formatting to the whole code base
- Sets up a check in the build to block unformatted cofe 