### PR TITLE
feat: list known features

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/YggdrasilEngineTest.cs
@@ -256,4 +256,33 @@ public class Tests
         var engine = new YggdrasilEngine();
         Assert.Throws<YggdrasilEngineException>(() => engine.TakeState(testData));
     }
+
+    [Test]
+    public void Features_That_Get_Set_Can_Be_Listed()
+    {
+        var testDataObject = new
+        {
+            Version = 2,
+            Features = new[] {
+                new {
+                    Name = "with.impression.data",
+                    Type = "release",
+                    Enabled = true,
+                    ImpressionData = true,
+                    Strategies = new [] {
+                        new {
+                            Name = "default",
+                            Parameters = new Dictionary<string, string>()
+                        }
+                    }
+                }
+            }
+        };
+
+        var testData = JsonSerializer.Serialize(testDataObject, options);
+        var engine = new YggdrasilEngine();
+        engine.TakeState(testData);
+        var knownFeatures = engine.ListKnownToggles();
+        Assert.AreEqual(1, knownFeatures.Count);
+    }
 }

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -27,6 +27,8 @@ internal static class FFI
     private static extern IntPtr should_emit_impression_event(IntPtr ptr, string toggle_name);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr built_in_strategies(IntPtr ptr);
+    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr list_known_toggles(IntPtr ptr);
 
     public static IntPtr NewEngine()
     {
@@ -91,5 +93,10 @@ internal static class FFI
     public static IntPtr BuiltInStrategies(IntPtr ptr)
     {
         return built_in_strategies(ptr);
+    }
+
+    public static IntPtr ListKnownToggles(IntPtr ptr)
+    {
+        return list_known_toggles(ptr);
     }
 }

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -72,6 +72,21 @@ public class Payload
     }
 }
 
+public class FeatureDefinition
+{
+    public FeatureDefinition(string name, string project, string? type)
+    {
+        Name = name;
+        Project = project;
+        Type = type;
+    }
+    public string Name { get; set; }
+
+    public string Project { get; set; }
+
+    public string? Type { get; set; }
+}
+
 public class YggdrasilEngineException : Exception
 {
     public YggdrasilEngineException(string message) : base(message) { }

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
@@ -83,4 +83,15 @@ public class YggdrasilEngine
     {
         FFI.CountVariant(state, featureName, variantName);
     }
+
+    public ICollection<FeatureDefinition> ListKnownToggles()
+    {
+        var featureDefinitionsPtr = FFI.ListKnownToggles(state);
+        var knownFeatures = FFIReader.ReadComplex<List<FeatureDefinition>>(featureDefinitionsPtr);
+        if (knownFeatures == null)
+        {
+            return new List<FeatureDefinition>();
+        }
+        return knownFeatures;
+    }
 }

--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -61,6 +61,8 @@ class YggdrasilEngine
   attach_function :count_toggle, %i[pointer string bool], :void
   attach_function :count_variant, %i[pointer string string], :void
 
+  attach_function :list_known_toggles, [:pointer], :pointer
+
   def initialize
     @engine = YggdrasilEngine.new_engine
     @custom_strategy_handler = CustomStrategyHandler.new
@@ -123,6 +125,13 @@ class YggdrasilEngine
     metrics = JSON.parse(metrics_ptr.read_string, symbolize_names: true)
     YggdrasilEngine.free_response(metrics_ptr)
     metrics[:value]
+  end
+
+  def list_known_toggles
+    response_ptr = YggdrasilEngine.list_known_toggles(@engine)
+    response_json = response_ptr.read_string
+    YggdrasilEngine.free_response(response_ptr)
+    JSON.parse(response_json, symbolize_names: true)
   end
 
   def register_custom_strategies(strategies)

--- a/ruby-engine/spec/yggdrasil_engine_spec.rb
+++ b/ruby-engine/spec/yggdrasil_engine_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe YggdrasilEngine do
 
       expect(metric[:variants][:disabled]).to eq(1)
     end
+
+    it 'should list all the features that were loaded' do
+      suite_path = File.join('../client-specification/specifications', '01-simple-examples.json')
+      suite_data = JSON.parse(File.read(suite_path))
+
+      yggdrasil_engine.take_state(suite_data['state'].to_json)
+
+      toggles = yggdrasil_engine.list_known_toggles()
+      expect(toggles.length).to eq(3)
+    end
   end
 end
 

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -395,6 +395,7 @@ pub unsafe extern "C" fn should_emit_impression_event(
 /// An invalid pointer to unleash engine will result in undefined behaviour.
 /// The caller is responsible for freeing the allocated memory, in case the response is not null. This can be done by calling
 /// `free_response` and passing in the pointer returned by this method. Failure to do so will result in a leak.
+#[no_mangle]
 pub unsafe extern "C" fn list_known_toggles(engine_ptr: *mut c_void) -> *mut c_char {
     let result: Result<Option<Vec<ToggleDefinition>>, FFIError> = (|| {
         let engine = get_engine(engine_ptr)?;

--- a/yggdrasilwasm/src/lib.rs
+++ b/yggdrasilwasm/src/lib.rs
@@ -193,4 +193,17 @@ impl Engine {
 
         serde_wasm_bindgen::to_value(&response).unwrap()
     }
+
+    #[wasm_bindgen(js_name = listKnownFeatures)]
+    pub fn list_known_toggles(&self) -> JsValue {
+        let known_toggles = self.engine.list_known_toggles();
+
+        let response = Response {
+            status_code: ResponseCode::Ok,
+            value: Some(known_toggles),
+            error_message: None,
+        };
+
+        serde_wasm_bindgen::to_value(&response).unwrap()
+    }
 }


### PR DESCRIPTION
Adds a very simple way to list the features known to the engine at the time of calling. This is to support SDKs like .NET/Go/Java which have a current option to list the features and is typically used to iterate those features and evaluate them all. For the consuming code, this produces a list of objects that look like


{
  "name" "The name of the feature toggle",
  "project": "The project the feature belongs to",
  "type": "Experiment, kill switch, etc, only sent if the feature response includes this, some older formats don't"
}

Currently only implemented in the FFI layers for Ruby and .NET.