### PR TITLE
chore: update build on dotnet to use release artifacts

### DIFF
--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -1,113 +1,45 @@
----
 name: .NET Publish
-
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: What version number would you like to use? The version number should be **without** a leading `v`, e.g. `5.7.1` or `6.2.4`.
-        required: true
 
 jobs:
-  # TODO: Consider making this its own workflow to be reused by other workflows.
-  build-binaries:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rid: linux-x64
-            output: libyggdrasilffi.so
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            rid: linux-arm64
-            output: libyggdrasilffi.so
-          - os: windows-latest
-            target: x86_64-pc-windows-gnu
-            rid: win-x64
-            output: yggdrasilffi.dll
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-            rid: win-arm64
-            output: yggdrasilffi.dll
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            rid: osx-x64
-            output: libyggdrasilffi.dylib
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            rid: osx-arm64
-            output: libyggdrasilffi.dylib
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies for aarch64-unknown-linux-gnu
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Configure cargo for cross-compilation
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          mkdir -p .cargo
-          echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config
-
-      - name: Install rust
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile default
-          rustup target add ${{ matrix.target }}
-          rustup show
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build yggdrasilffi
-        run: |
-          cargo build -p yggdrasilffi --release --target ${{ matrix.target }}
-
-      - name: Upload yggdrasilffi binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.rid }}
-          path: target/${{ matrix.target }}/release/${{ matrix.output }}
 
   publish:
-    needs: build-binaries
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download yggdrasilffi binaries
-        run: |
-          for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
-            mkdir -p dotnet-engine/runtimes/${rid}/native
-            echo "Downloading artifact for $rid"
-            if ! gh run download --name $rid --dir dotnet-engine/runtimes/${rid}/native; then
-              echo "Failed to download artifact for $rid, continuing..."
-            fi
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # - name: Download yggdrasilffi binaries
+      #   run: |
+      #     for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
+      #       mkdir -p dotnet-engine/runtimes/${rid}/native
+      #       echo "Downloading artifact for $rid"
+      #       if ! gh run download --name $rid --dir dotnet-engine/runtimes/${rid}/native; then
+      #         echo "Failed to download artifact for $rid, continuing..."
+      #       fi
+      #     done
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 
+      - name: Extract Yggdrasil Core Version
+        id: extract_ffi_version
+        run: |
+          sudo apt-get install -y xmlstarlet
+          cd dotnet-engine/Yggdrasil.Engine
+          CORE_VERSION=$(xmlstarlet sel -t -v "/Project/PropertyGroup/YggdrasilCoreVersion" -n Yggdrasil.Engine.csproj)
+          echo "FFI Library Version: $CORE_VERSION"
+          echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
+
       - name: Restore dependencies
         run: |
           cd dotnet-engine
           dotnet restore dotnet-engine.sln
-
-      - name: Set version
-        run: |
-          cd dotnet-engine
-          version=${{ github.event.inputs.version }}
-          sed -i "s/<Version>.*<\/Version>/<Version>$version<\/Version>/" Yggdrasil.Engine/Yggdrasil.Engine.csproj
 
       - name: Build
         run: |
@@ -124,13 +56,13 @@ jobs:
           cd dotnet-engine
           ls -lh Yggdrasil.Engine/bin/Release/*nupkg
 
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: yggdrasil-nuget
-          path: dotnet-engine/Yggdrasil.Engine/bin/Release/*nupkg
+      # - name: Upload package artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: yggdrasil-nuget
+      #     path: dotnet-engine/Yggdrasil.Engine/bin/Release/*nupkg
 
-      - name: Publish package
-        run: |
-          cd dotnet-engine
-          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+      # - name: Publish package
+      #   run: |
+      #     cd dotnet-engine
+      #     dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -29,14 +29,13 @@ jobs:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd dotnet-engine
-          binaries=("libyggdrasilffi_aarch64.so linux/aarch64/libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.dll windows/arm64/libyggdrasilffi.dll"
-                    "libyggdrasilffi_arm64.dylib macos/arm64/libyggdrasilffi.dylib"
-                    "libyggdrasilffi_arm64.so linux/arm/libyggdrasilffi.so"
-                    "libyggdrasilffi_x86_64.dll windows/x86_64/libyggdrasilffi.dll"
-                    "libyggdrasilffi_x86_64.dylib macos/x86_64/libyggdrasilffi.dylib"
-                    "libyggdrasilffi_x86_64.so linux/x86_64/libyggdrasilffi.so")
+          binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native/libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native/libyggdrasilffi.so"
+                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native/libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native/yggdrasilffi.dll"
+                    "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native/yggdrasilffi.dll"
+                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native/libyggdrasilffi.dylib"
+                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native/libyggdrasilffi.dylib")
 
           for binary in "${binaries[@]}"; do
             # Split each item into source (release name) and target path

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -29,36 +29,37 @@ jobs:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native/libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native/libyggdrasilffi.so"
-                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native/libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native/yggdrasilffi.dll"
-                    "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native/yggdrasilffi.dll"
-                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native/libyggdrasilffi.dylib"
-                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native/libyggdrasilffi.dylib")
+          binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
+                    "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
+                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
+                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
 
           for binary in "${binaries[@]}"; do
             # Split each item into source (release name) and target path
             src_name=$(echo "$binary" | awk '{print $1}')
             target_path=$(echo "$binary" | awk '{print $2}')
+            binary_name=$(echo "$binary" | awk '{print $3}')
 
             echo "Downloading $src_name to $target_path..."
 
-            mkdir -p "$(dirname "$target_path")"
+            mkdir -p "$target_path"
 
-            curl -L -o "$target_path" \
+            curl -L -o "$target_path/$binary_name" \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/$src_name"
+              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/${src_name}"
 
-            if [ -f "$target_path" ]; then
+            if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."
             else
               echo "Error: $src_name could not be downloaded to $target_path."
               exit 1
             fi
+            ls -l "$target_path"
           done
-          echo "Downloaded binaries:"
-          find . -type f -name "libyggdrasilffi*"
+          echo "Downloaded binaries"
 
       - name: Build
         run: |

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -24,11 +24,11 @@ jobs:
           echo "FFI Library Version: $CORE_VERSION"
           echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
 
-      - name: Set up artifact names
+      - name: Download and Organize Binaries
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # List of binaries and corresponding target paths
           binaries=("libyggdrasilffi_aarch64.so linux/aarch64/libyggdrasilffi.so"
                     "libyggdrasilffi_arm64.dll windows/arm64/libyggdrasilffi.dll"
                     "libyggdrasilffi_arm64.dylib macos/arm64/libyggdrasilffi.dylib"
@@ -37,14 +37,8 @@ jobs:
                     "libyggdrasilffi_x86_64.dylib macos/x86_64/libyggdrasilffi.dylib"
                     "libyggdrasilffi_x86_64.so linux/x86_64/libyggdrasilffi.so")
 
-          echo "binaries=${binaries[@]}" >> $GITHUB_ENV
-
-      - name: Download and Organize Binaries
-        env:
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
           for binary in "${binaries[@]}"; do
+            # Split each item into source (release name) and target path
             src_name=$(echo "$binary" | awk '{print $1}')
             target_path=$(echo "$binary" | awk '{print $2}')
 
@@ -52,7 +46,6 @@ jobs:
 
             mkdir -p "$(dirname "$target_path")"
 
-            # Direct download using GitHub's release download URL
             curl -L -o "$target_path" \
               -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/$src_name"
@@ -63,9 +56,6 @@ jobs:
               echo "Error: $src_name could not be downloaded to $target_path."
             fi
           done
-
-      - name: Verify Downloaded Files
-        run: |
           echo "Downloaded binaries:"
           find . -type f -name "libyggdrasilffi*"
 

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -77,4 +77,4 @@ jobs:
       - name: Publish package
         run: |
           cd dotnet-engine
-          # dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -50,6 +50,8 @@ jobs:
               -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
 
+            echo "Downloading from https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
+
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."
             else

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -48,9 +48,9 @@ jobs:
 
             curl -L -o "$target_path/$binary_name" \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
+              "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
-            echo "Downloaded from https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
+            echo "Downloaded from https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -54,6 +54,7 @@ jobs:
               echo "$src_name downloaded successfully to $target_path."
             else
               echo "Error: $src_name could not be downloaded to $target_path."
+              exit 1
             fi
           done
           echo "Downloaded binaries:"
@@ -71,13 +72,7 @@ jobs:
           cd dotnet-engine
           ls -lh Yggdrasil.Engine/bin/Release/*nupkg
 
-      # - name: Upload package artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: yggdrasil-nuget
-      #     path: dotnet-engine/Yggdrasil.Engine/bin/Release/*nupkg
-
-      # - name: Publish package
-      #   run: |
-      #     cd dotnet-engine
-      #     dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+      - name: Publish package
+        run: |
+          cd dotnet-engine
+          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Pack
         run: |
           cd dotnet-engine
-          dotnet pack dotnet-engine.sln -c Rele`ase --no-build --no-restore
+          dotnet pack dotnet-engine.sln -c Release --no-build --no-restore
 
       - name: Check package size
         run: |

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -48,7 +48,6 @@ jobs:
             mkdir -p "$target_path"
 
             curl -L -o "$target_path/$binary_name" \
-              -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/${src_name}"
 
             if [ -f "$target_path/$binary_name" ]; then

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -26,47 +26,39 @@ jobs:
 
       - name: Download and Organize Binaries
         env:
-          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
+                    "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
+                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
+                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
 
+          for binary in "${binaries[@]}"; do
+            # Split each item into source (release name) and target path
+            src_name=$(echo "$binary" | awk '{print $1}')
+            target_path=$(echo "$binary" | awk '{print $2}')
+            binary_name=$(echo "$binary" | awk '{print $3}')
 
-          mkdir -p dotnet-engine/runtimes/linux-aarch64/native
+            echo "Downloading $src_name to $target_path..."
 
-          curl -L -o dotnet-engine/runtimes/linux-aarch64/native/libyggdrasilffi.so \
-            https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v0.14.0/libyggdrasilffi_aarch64.so
+            mkdir -p "$target_path"
 
-          # binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native libyggdrasilffi.so"
-          #           "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
-          #           "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
-          #           "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
-          #           "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
-          #           "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
-          #           "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
+            curl -L -o "$target_path/$binary_name" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
 
-          # for binary in "${binaries[@]}"; do
-          #   # Split each item into source (release name) and target path
-          #   src_name=$(echo "$binary" | awk '{print $1}')
-          #   target_path=$(echo "$binary" | awk '{print $2}')
-          #   binary_name=$(echo "$binary" | awk '{print $3}')
-
-          #   echo "Downloading $src_name to $target_path..."
-
-          #   mkdir -p "$target_path"
-
-          #   https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v0.14.0/libyggdrasilffi_aarch64.so
-          #   curl -L -o "$target_path/$binary_name" \
-          #     "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/${src_name}"
-
-          #   if [ -f "$target_path/$binary_name" ]; then
-          #     echo "$src_name downloaded successfully to $target_path."
-          #   else
-          #     echo "Error: $src_name could not be downloaded to $target_path."
-          #     exit 1
-          #   fi
-          #   ls -l "$target_path"
-          # done
-          # echo "Downloaded binaries"
+            if [ -f "$target_path/$binary_name" ]; then
+              echo "$src_name downloaded successfully to $target_path."
+            else
+              echo "Error: $src_name could not be downloaded to $target_path."
+              exit 1
+            fi
+            ls -l "$target_path"
+          done
+          echo "Downloaded binaries"
 
       - name: Build
         run: |

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -1,4 +1,4 @@
-name: .NET Publish
+name: Publish .NET
 on:
   workflow_dispatch:
 

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -28,40 +28,39 @@ jobs:
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
-          declare -A binaries
-          binaries=(
-            ["libyggdrasilffi_aarch64.so"]="linux/aarch64/libyggdrasilffi.so"
-            ["libyggdrasilffi_arm64.dll"]="windows/arm64/libyggdrasilffi.dll"
-            ["libyggdrasilffi_arm64.dylib"]="macos/arm64/libyggdrasilffi.dylib"
-            ["libyggdrasilffi_arm64.so"]="linux/arm/libyggdrasilffi.so"
-            ["libyggdrasilffi_x86_64.dll"]="windows/x86_64/libyggdrasilffi.dll"
-            ["libyggdrasilffi_x86_64.dylib"]="macos/x86_64/libyggdrasilffi.dylib"
-            ["libyggdrasilffi_x86_64.so"]="linux/x86_64/libyggdrasilffi.so"
-          )
+          # List of binaries and corresponding target paths
+          binaries=("libyggdrasilffi_aarch64.so linux/aarch64/libyggdrasilffi.so"
+                    "libyggdrasilffi_arm64.dll windows/arm64/libyggdrasilffi.dll"
+                    "libyggdrasilffi_arm64.dylib macos/arm64/libyggdrasilffi.dylib"
+                    "libyggdrasilffi_arm64.so linux/arm/libyggdrasilffi.so"
+                    "libyggdrasilffi_x86_64.dll windows/x86_64/libyggdrasilffi.dll"
+                    "libyggdrasilffi_x86_64.dylib macos/x86_64/libyggdrasilffi.dylib"
+                    "libyggdrasilffi_x86_64.so linux/x86_64/libyggdrasilffi.so")
 
-          echo "binaries=${!binaries[@]}" >> $GITHUB_ENV
+          echo "binaries=${binaries[@]}" >> $GITHUB_ENV
 
       - name: Download and Organize Binaries
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for binary in ${binaries[@]}; do
-            target_path="${binaries[$binary]}"
-            echo "Downloading $binary to $target_path..."
+          for binary in "${binaries[@]}"; do
+            src_name=$(echo "$binary" | awk '{print $1}')
+            target_path=$(echo "$binary" | awk '{print $2}')
 
-            # Create the target directory if it doesn't exist
+            echo "Downloading $src_name to $target_path..."
+
             mkdir -p "$(dirname "$target_path")"
 
-            # Direct download using GitHub's direct URL pattern
+            # Direct download using GitHub's release download URL
             curl -L -o "$target_path" \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/$binary"
+              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/$src_name"
 
             if [ -f "$target_path" ]; then
-              echo "$binary downloaded successfully to $target_path."
+              echo "$src_name downloaded successfully to $target_path."
             else
-              echo "Error: $binary could not be downloaded to $target_path."
+              echo "Error: $src_name could not be downloaded to $target_path."
             fi
           done
 

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -48,7 +48,7 @@ jobs:
 
             curl -L -o "$target_path/$binary_name" \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
+              "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -10,18 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Download yggdrasilffi binaries
-      #   run: |
-      #     for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
-      #       mkdir -p dotnet-engine/runtimes/${rid}/native
-      #       echo "Downloading artifact for $rid"
-      #       if ! gh run download --name $rid --dir dotnet-engine/runtimes/${rid}/native; then
-      #         echo "Failed to download artifact for $rid, continuing..."
-      #       fi
-      #     done
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-
       - name: Set up .NET
         uses: actions/setup-dotnet@v3
         with:
@@ -36,6 +24,14 @@ jobs:
           echo "FFI Library Version: $CORE_VERSION"
           echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
 
+      - name: Download binaries
+        run: |
+          mkdir -p dotnet-engine/runtimes/linux-arm64/native
+          echo "Downloading artifact for linux-arm64"
+          curl -L -o dotnet-engine/runtimes/linux-arm64/native/libyggdrasilffi.so \
+            "https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v${{ env.CORE_VERSION }}/libyggdrasilffi_aarch64.so"
+
+
       - name: Restore dependencies
         run: |
           cd dotnet-engine
@@ -49,7 +45,7 @@ jobs:
       - name: Pack
         run: |
           cd dotnet-engine
-          dotnet pack dotnet-engine.sln -c Release --no-build --no-restore
+          dotnet pack dotnet-engine.sln -c Rele`ase --no-build --no-restore
 
       - name: Check package size
         run: |

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -24,27 +24,57 @@ jobs:
           echo "FFI Library Version: $CORE_VERSION"
           echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
 
-      - name: Download binaries
+      - name: Set up artifact names
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
-          mkdir -p dotnet-engine/runtimes/linux-arm64/native
-          echo "Downloading artifact for linux-arm64"
-          curl -L -o dotnet-engine/runtimes/linux-arm64/native/libyggdrasilffi.so \
-            "https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v${{ env.CORE_VERSION }}/libyggdrasilffi_aarch64.so"
+          declare -A binaries
+          binaries=(
+            ["libyggdrasilffi_aarch64.so"]="linux/aarch64/libyggdrasilffi.so"
+            ["libyggdrasilffi_arm64.dll"]="windows/arm64/libyggdrasilffi.dll"
+            ["libyggdrasilffi_arm64.dylib"]="macos/arm64/libyggdrasilffi.dylib"
+            ["libyggdrasilffi_arm64.so"]="linux/arm/libyggdrasilffi.so"
+            ["libyggdrasilffi_x86_64.dll"]="windows/x86_64/libyggdrasilffi.dll"
+            ["libyggdrasilffi_x86_64.dylib"]="macos/x86_64/libyggdrasilffi.dylib"
+            ["libyggdrasilffi_x86_64.so"]="linux/x86_64/libyggdrasilffi.so"
+          )
 
+          echo "binaries=${!binaries[@]}" >> $GITHUB_ENV
 
-      - name: Restore dependencies
+      - name: Download and Organize Binaries
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd dotnet-engine
-          dotnet restore dotnet-engine.sln
+          for binary in ${binaries[@]}; do
+            target_path="${binaries[$binary]}"
+            echo "Downloading $binary to $target_path..."
+
+            # Create the target directory if it doesn't exist
+            mkdir -p "$(dirname "$target_path")"
+
+            # Direct download using GitHub's direct URL pattern
+            curl -L -o "$target_path" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/$binary"
+
+            if [ -f "$target_path" ]; then
+              echo "$binary downloaded successfully to $target_path."
+            else
+              echo "Error: $binary could not be downloaded to $target_path."
+            fi
+          done
+
+      - name: Verify Downloaded Files
+        run: |
+          echo "Downloaded binaries:"
+          find . -type f -name "libyggdrasilffi*"
 
       - name: Build
         run: |
           cd dotnet-engine
+          dotnet restore dotnet-engine.sln
           dotnet build dotnet-engine.sln -c Release --no-restore
-
-      - name: Pack
-        run: |
-          cd dotnet-engine
           dotnet pack dotnet-engine.sln -c Release --no-build --no-restore
 
       - name: Check package size

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -50,8 +50,6 @@ jobs:
               -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
 
-            echo "Downloading from https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
-
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."
             else
@@ -77,4 +75,4 @@ jobs:
       - name: Publish package
         run: |
           cd dotnet-engine
-          # dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -29,6 +29,7 @@ jobs:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cd dotnet-engine
           binaries=("libyggdrasilffi_aarch64.so linux/aarch64/libyggdrasilffi.so"
                     "libyggdrasilffi_arm64.dll windows/arm64/libyggdrasilffi.dll"
                     "libyggdrasilffi_arm64.dylib macos/arm64/libyggdrasilffi.dylib"
@@ -75,4 +76,4 @@ jobs:
       - name: Publish package
         run: |
           cd dotnet-engine
-          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          # dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -48,9 +48,9 @@ jobs:
 
             curl -L -o "$target_path/$binary_name" \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
+              "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
 
-            echo "Downloading from https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
+            echo "Downloading from https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-${CORE_VERSION}/${src_name}"
 
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -50,6 +50,8 @@ jobs:
               -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
+            echo "Downloaded from https://github.com/${{ github.repository }}/releases/tag/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
+
             if [ -f "$target_path/$binary_name" ]; then
               echo "$src_name downloaded successfully to $target_path."
             else
@@ -75,4 +77,4 @@ jobs:
       - name: Publish package
         run: |
           cd dotnet-engine
-          dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          # dotnet nuget push Yggdrasil.Engine/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -29,36 +29,44 @@ jobs:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
-                    "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
-                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
-                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
 
-          for binary in "${binaries[@]}"; do
-            # Split each item into source (release name) and target path
-            src_name=$(echo "$binary" | awk '{print $1}')
-            target_path=$(echo "$binary" | awk '{print $2}')
-            binary_name=$(echo "$binary" | awk '{print $3}')
 
-            echo "Downloading $src_name to $target_path..."
+          mkdir -p dotnet-engine/runtimes/linux-aarch64/native
 
-            mkdir -p "$target_path"
+          curl -L -o dotnet-engine/runtimes/linux-aarch64/native/libyggdrasilffi.so \
+            https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v0.14.0/libyggdrasilffi_aarch64.so
 
-            curl -L -o "$target_path/$binary_name" \
-              "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/${src_name}"
+          # binaries=("libyggdrasilffi_aarch64.so dotnet-engine/runtimes/linux-aarch64/native libyggdrasilffi.so"
+          #           "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
+          #           "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
+          #           "libyggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
+          #           "libyggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
+          #           "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
+          #           "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
 
-            if [ -f "$target_path/$binary_name" ]; then
-              echo "$src_name downloaded successfully to $target_path."
-            else
-              echo "Error: $src_name could not be downloaded to $target_path."
-              exit 1
-            fi
-            ls -l "$target_path"
-          done
-          echo "Downloaded binaries"
+          # for binary in "${binaries[@]}"; do
+          #   # Split each item into source (release name) and target path
+          #   src_name=$(echo "$binary" | awk '{print $1}')
+          #   target_path=$(echo "$binary" | awk '{print $2}')
+          #   binary_name=$(echo "$binary" | awk '{print $3}')
+
+          #   echo "Downloading $src_name to $target_path..."
+
+          #   mkdir -p "$target_path"
+
+          #   https://github.com/Unleash/yggdrasil/releases/download/unleash-yggdrasil-v0.14.0/libyggdrasilffi_aarch64.so
+          #   curl -L -o "$target_path/$binary_name" \
+          #     "https://github.com/${{ github.repository }}/releases/download/${RELEASE_VERSION}/${src_name}"
+
+          #   if [ -f "$target_path/$binary_name" ]; then
+          #     echo "$src_name downloaded successfully to $target_path."
+          #   else
+          #     echo "Error: $src_name could not be downloaded to $target_path."
+          #     exit 1
+          #   fi
+          #   ls -l "$target_path"
+          # done
+          # echo "Downloaded binaries"
 
       - name: Build
         run: |

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.0-beta.7</Version>
+    <Version>1.0.0-beta.8</Version>
     <YggdrasilCoreVersion>0.14.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.0-beta.6</Version>
+    <Version>1.0.0-beta.7</Version>
     <YggdrasilCoreVersion>0.14.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.0-beta.5</Version>
+    <Version>1.0.0-beta.6</Version>
     <YggdrasilCoreVersion>0.14.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.0-beta.1</Version>
+    <Version>1.0.0-beta.5</Version>
+    <YggdrasilCoreVersion>0.14.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>
     <IncludeSymbols>True</IncludeSymbols>


### PR DESCRIPTION
Binary build is now handled by a completely different task that's fired on `cargo smart-release` (or just pushing a tag, but don't do that).

The .NET build now picks up the binaries from the release artifacts, and uses an internal property - YggdrasilCoreVersion in its build files to set the version of Yggdrasil FFI that will be used. This means that our versioning is now tracked in source control