### PR TITLE
chore: publish musl binaries with correct names

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -28,19 +28,24 @@ jobs:
             name: libyggdrasilffi_arm64.so
             cross: true
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            output: libyggdrasilffi.so
+            name: libyggdrasilffi_x86_64-musl.so
+            cross: true
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             output: libyggdrasilffi.so
-            name: libyggdrasilffi_aarch64.so
+            name: libyggdrasilffi_arm64-musl.so
             cross: true
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             output: yggdrasilffi.dll
-            name: libyggdrasilffi_x86_64.dll
+            name: yggdrasilffi_x86_64.dll
             cross: false
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             output: yggdrasilffi.dll
-            name: libyggdrasilffi_arm64.dll
+            name: yggdrasilffi_arm64.dll
             cross: true
           - os: macos-13
             target: x86_64-apple-darwin


### PR DESCRIPTION
Gives us a binary for ARM-musl and x86-musl. Previously we only had a ARM-musl binary

Gives Windows binaries the name they're expected to use