### PR TITLE
chore: cross for more builds

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -21,68 +21,52 @@ jobs:
             target: x86_64-unknown-linux-gnu
             output: libyggdrasilffi.so
             name: libyggdrasilffi_x86_64.so
-            cross: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             output: libyggdrasilffi.so
             name: libyggdrasilffi_arm64.so
-            cross: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             output: libyggdrasilffi.so
             name: libyggdrasilffi_x86_64-musl.so
-            cross: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             output: libyggdrasilffi.so
             name: libyggdrasilffi_arm64-musl.so
-            cross: true
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             output: yggdrasilffi.dll
             name: yggdrasilffi_x86_64.dll
-            cross: false
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             output: yggdrasilffi.dll
             name: yggdrasilffi_arm64.dll
-            cross: true
           - os: macos-13
             target: x86_64-apple-darwin
             output: libyggdrasilffi.dylib
             name: libyggdrasilffi_x86_64.dylib
-            cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
             output: libyggdrasilffi.dylib
             name: libyggdrasilffi_arm64.dylib
-            cross: false
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install cross (if needed)
-      if: ${{ matrix.cross == true }}
-      run: cargo install cross
-
-    - name: Install rust
+    - name: Install Rust + Cross
       run: |
         rustup set auto-self-update disable
         rustup toolchain install stable --profile default
+        cargo install cross
+        rustup target add aarch64-pc-windows-msvc
         rustup show
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Build Rust Library (Cross)
-      if: ${{ matrix.cross == true }}
+    - name: Build Rust Library
       run: |
-        rustup target add aarch64-pc-windows-msvc
         cross build -p yggdrasilffi --release --target ${{ matrix.target }};
-
-    - name: Build Rust Library (Cargo)
-      if: ${{ matrix.cross == false }}
-      run: cargo build -p yggdrasilffi --release --target ${{ matrix.target }};
 
     - name: Rename Output Binary
       run: |
@@ -130,13 +114,13 @@ jobs:
           }
         result-encoding: json
 
-    - name: Upload Binary to Release
-      if: ${{ steps.get_release.outputs.upload_url }}
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
-        asset_name: "${{ matrix.name }}"
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - name: Upload Binary to Release
+    #   if: ${{ steps.get_release.outputs.upload_url }}
+    #   uses: actions/upload-release-asset@v1
+    #   with:
+    #     upload_url: ${{ steps.get_release.outputs.upload_url }}
+    #     asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
+    #     asset_name: "${{ matrix.name }}"
+    #     asset_content_type: application/octet-stream
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -21,26 +21,32 @@ jobs:
             target: x86_64-unknown-linux-gnu
             output: libyggdrasilffi.so
             name: libyggdrasilffi_x86_64.so
+            cross: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             output: libyggdrasilffi.so
             name: libyggdrasilffi_arm64.so
+            cross: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             output: libyggdrasilffi.so
             name: libyggdrasilffi_x86_64-musl.so
+            cross: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             output: libyggdrasilffi.so
             name: libyggdrasilffi_arm64-musl.so
+            cross: true
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             output: yggdrasilffi.dll
             name: yggdrasilffi_x86_64.dll
+            cross: false
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             output: yggdrasilffi.dll
             name: yggdrasilffi_arm64.dll
+            cross: true
           - os: macos-13
             target: x86_64-apple-darwin
             output: libyggdrasilffi.dylib
@@ -49,24 +55,33 @@ jobs:
             target: aarch64-apple-darwin
             output: libyggdrasilffi.dylib
             name: libyggdrasilffi_arm64.dylib
+            cross: true
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust + Cross
+    - name: Install cross (if needed)
+      if: ${{ matrix.cross == true }}
+      run: cargo install cross
+
+    - name: Install rust
       run: |
         rustup set auto-self-update disable
         rustup toolchain install stable --profile default
-        cargo install cross
         rustup show
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Build Rust Library
+    - name: Build Rust Library (Cross)
+      if: ${{ matrix.cross == true }}
       run: |
         rustup target add ${{ matrix.target }}
-        cross build -p yggdrasilffi --release --target ${{ matrix.target }}
+        cross build -p yggdrasilffi --release --target ${{ matrix.target }};
+
+    - name: Build Rust Library (Cargo)
+      if: ${{ matrix.cross == false }}
+      run: cargo build -p yggdrasilffi --release --target ${{ matrix.target }};
 
     - name: Rename Output Binary
       run: |

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -58,7 +58,6 @@ jobs:
         rustup set auto-self-update disable
         rustup toolchain install stable --profile default
         cargo install cross
-        rustup target add aarch64-pc-windows-msvc
         rustup show
 
     - name: Rust cache
@@ -66,7 +65,8 @@ jobs:
 
     - name: Build Rust Library
       run: |
-        cross build -p yggdrasilffi --release --target ${{ matrix.target }};
+        rustup target add ${{ matrix.target }}
+        cross build -p yggdrasilffi --release --target ${{ matrix.target }}
 
     - name: Rename Output Binary
       run: |

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -129,13 +129,13 @@ jobs:
           }
         result-encoding: json
 
-    # - name: Upload Binary to Release
-    #   if: ${{ steps.get_release.outputs.upload_url }}
-    #   uses: actions/upload-release-asset@v1
-    #   with:
-    #     upload_url: ${{ steps.get_release.outputs.upload_url }}
-    #     asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
-    #     asset_name: "${{ matrix.name }}"
-    #     asset_content_type: application/octet-stream
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload Binary to Release
+      if: ${{ steps.get_release.outputs.upload_url }}
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}
+        asset_path: target/${{ matrix.target }}/release/${{ matrix.name }}
+        asset_name: "${{ matrix.name }}"
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Swaps out the Mac and Linux cargo builds for cross. Cross more widely compatible native libraries that we link against (for the Linux case, glibc, which means we work on older Debian versions).

Apparently there's no cross target for windows x86 and so we're stuck with the cargo/cross choice rather than doing everything through cross