### PR TITLE
fix: bring python back to working state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /php-engine/unleash_engine.h
 /php-engine/libyggdrasilffi.so
 /ruby-engine/lib/libyggdrasilffi*.*
+/python-engine/lib/
 
 # Devenv
 .devenv*

--- a/python-engine/build.sh
+++ b/python-engine/build.sh
@@ -1,3 +1,6 @@
 cargo build --release
 mkdir -p lib
-cp ../target/release/libyggdrasilffi.so ./lib/
+
+[ -f ../target/release/yggdrasilffi.dll ] && cp ../target/release/yggdrasilffi.dll ./lib
+[ -f ../target/release/libyggdrasilffi.dylib ] && cp ../target/release/libyggdrasilffi.dylib ./lib
+[ -f ../target/release/libyggdrasilffi.so ] && cp ../target/release/libyggdrasilffi.so ./lib

--- a/python-engine/build.sh
+++ b/python-engine/build.sh
@@ -1,0 +1,3 @@
+cargo build --release
+mkdir -p lib
+cp ../target/release/libyggdrasilffi.so ./lib/

--- a/python-engine/test_unleash_engine.py
+++ b/python-engine/test_unleash_engine.py
@@ -1,8 +1,13 @@
+from dataclasses import asdict
 import json
-import pytest
-from unleash_engine import UnleashEngine
+from unleash_engine import UnleashEngine, Variant
 import json
 import os
+
+
+def variant_to_dict(variant) -> dict:
+    print(variant)
+    return {k: v for k, v in asdict(variant).items() if v is not None}
 
 
 def test_get_variant_does_not_crash():
@@ -36,7 +41,7 @@ def test_client_spec():
             toggle_name = test["toggleName"]
             expected_result = test["expectedResult"]
 
-            result = unleash_engine.is_enabled(toggle_name, context)
+            result = unleash_engine.is_enabled(toggle_name, context) or False
 
             assert (
                 result == expected_result
@@ -47,8 +52,15 @@ def test_client_spec():
             toggle_name = test["toggleName"]
             expected_result = test["expectedResult"]
 
-            result = unleash_engine.get_variant(toggle_name, context)
+            result = unleash_engine.get_variant(toggle_name, context) or Variant(
+                "disabled", None, False, False
+            )
+
+            ## We get away with this right now because the casing in the spec tests for feature_enabled
+            ## is snake_case. At some point this is going to change to camel case and this is going to break
+            expected_json = json.dumps(expected_result)
+            actual_json = json.dumps(variant_to_dict(result))
 
             assert (
-                result == expected_result
-            ), f"Failed test '{test['description']}': expected {expected_result}, got {result}"
+                expected_json == actual_json
+            ), f"Failed test '{test['description']}': expected {expected_json}, got {actual_json}"

--- a/python-engine/unleash_engine.py
+++ b/python-engine/unleash_engine.py
@@ -1,57 +1,164 @@
 import ctypes
 import json
 import os
+import platform
+from contextlib import contextmanager
+from enum import Enum
+from dataclasses import dataclass, field
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, TypeVar, cast
+
+
+def _get_binary_path():
+    lib_dir = os.path.join(os.path.dirname(__file__), "lib")
+    system = platform.system()
+
+    if system == "Linux":
+        return os.path.join(lib_dir, "libyggdrasilffi.so")
+    elif system == "Darwin":
+        return os.path.join(lib_dir, "libyggdrasilffi.dylib")
+    elif system == "Windows":
+        return os.path.join(lib_dir, "yggdrasilffi.so.dll")
+    else:
+        raise RuntimeError(f"Unsupported operating system: {system}")
+
+
+T = TypeVar("T")
+
+
+class StatusCode(Enum):
+    OK = "Ok"
+    NOT_FOUND = "NotFound"
+    ERROR = "Error"
+
+
+class YggdrasilError(Exception):
+    pass
+
+
+@dataclass
+class Variant:
+    name: str
+    payload: Optional[Dict[str, str]] = field(default_factory=dict)
+    enabled: bool = False
+    feature_enabled: bool = False
+
+    @staticmethod
+    def from_dict(data: dict) -> "Variant":
+        return Variant(
+            name=data.get("name", ""),
+            payload=data.get("payload"),
+            enabled=data.get("enabled", False),
+            feature_enabled=data.get("featureEnabled", False),
+        )
+
+
+@dataclass
+class Response:
+    status_code: StatusCode
+    value: Optional[any]
+    error_message: Optional[str]
+
+    # this only exists to handle feature_enabled/featureEnabled
+    deserializers: ClassVar[Dict[Type, Callable[[Any], Any]]] = {
+        Variant: Variant.from_dict,
+    }
+
+    @staticmethod
+    def from_json(data: str, value_type: Type[T]) -> "Response[T]":
+        status_code = StatusCode(data["status_code"])
+        raw_value = data.get("value")
+        error_message = data.get("error_message")
+
+        if raw_value is not None:
+            if value_type in Response.deserializers:
+                value = Response.deserializers[value_type](raw_value)
+            else:
+                value = cast(value_type, raw_value)
+        else:
+            value = None
+
+        return Response(
+            status_code=status_code, value=value, error_message=error_message
+        )
 
 
 class UnleashEngine:
     def __init__(self):
-        lib_path = os.environ.get("YGGDRASIL_LIB_PATH")
-        if lib_path is None:
-            raise Exception("YGGDRASIL_LIB_PATH not set")
-        combined_path = os.path.join(lib_path, "libyggdrasilffi.so")
+        binary_path = _get_binary_path()
 
-        self.lib = ctypes.CDLL(combined_path)
-        self.lib.engine_new.restype = ctypes.c_void_p
-        self.lib.engine_take_state.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-        self.lib.engine_take_state.restype = ctypes.c_char_p
-        self.lib.engine_is_enabled.argtypes = [
+        self.lib = ctypes.CDLL(binary_path)
+        self.lib.new_engine.restype = ctypes.c_void_p
+        self.lib.take_state.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        self.lib.take_state.restype = ctypes.POINTER(ctypes.c_char)
+        self.lib.check_enabled.argtypes = [
             ctypes.c_void_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
+            ctypes.c_char_p,
         ]
-        self.lib.engine_is_enabled.restype = ctypes.c_bool
-        self.lib.engine_get_variant.argtypes = [
+        self.lib.check_enabled.restype = ctypes.POINTER(ctypes.c_char)
+        self.lib.check_variant.argtypes = [
             ctypes.c_void_p,
             ctypes.c_char_p,
             ctypes.c_char_p,
+            ctypes.c_char_p,
         ]
-        self.lib.engine_get_variant.restype = ctypes.c_char_p
-        self.lib.engine_free.argtypes = [ctypes.c_void_p]
-        self.lib.engine_free.restype = None
+        self.lib.check_variant.restype = ctypes.POINTER(ctypes.c_char)
+        self.lib.free_engine.argtypes = [ctypes.c_void_p]
+        self.lib.free_engine.restype = None
+        self.lib.free_response.argtypes = [ctypes.c_void_p]
+        self.lib.free_response.restype = None
 
-        self.state = self.lib.engine_new()
+        self.state = self.lib.new_engine()
 
     def __del__(self):
         if hasattr(self, "state") and self.state is not None:
-            self.lib.engine_free(self.state)
+            self.lib.free_engine(self.state)
 
-    def take_state(self, state_json):
-        result_ptr = self.lib.engine_take_state(self.state, state_json.encode("utf-8"))
-        return result_ptr.decode("utf-8")
+    @contextmanager
+    def materialize_pointer(self, ptr, value_type: Type[T]):
+        try:
+            response = ctypes.cast(ptr, ctypes.c_char_p).value.decode("utf-8")
+            yield Response.from_json(json.loads(response), value_type)
+        finally:
+            self.lib.free_response(ptr)
 
-    def is_enabled(self, toggle_name, context):
-        serialized_context = json.dumps(context)
-        return self.lib.engine_is_enabled(
-            self.state, toggle_name.encode("utf-8"), serialized_context.encode("utf-8")
-        )
-
-    def get_variant(self, toggle_name, context):
-        serialized_context = json.dumps(context)
-        variant_json_ptr = self.lib.engine_get_variant(
-            self.state, toggle_name.encode("utf-8"), serialized_context.encode("utf-8")
-        )
-        if variant_json_ptr:
-            variant_json = variant_json_ptr.decode("utf-8")
-            return json.loads(variant_json)
-        else:
+    def take_state(self, state_json: str) -> Optional[List[Warning]]:
+        response_ptr = self.lib.take_state(self.state, state_json.encode("utf-8"))
+        with self.materialize_pointer(response_ptr, List[Warning]) as result:
+            if result.value:
+                warnings = "\n".join(
+                    [f"{warning.toggle_name}: {warning.message}" for warning in result]
+                )
+                return warnings
             return None
+
+    def is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
+        serialized_context = json.dumps(context or {})
+        custom_strategy_results = json.dumps({})
+
+        response_ptr = self.lib.check_enabled(
+            self.state,
+            toggle_name.encode("utf-8"),
+            serialized_context.encode("utf-8"),
+            custom_strategy_results.encode("utf-8"),
+        )
+        with self.materialize_pointer(response_ptr, bool) as response:
+            if response.status_code == StatusCode.ERROR:
+                raise YggdrasilError(response.error_message)
+            return response.value
+
+    def get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
+        serialized_context = json.dumps(context or {})
+        custom_strategy_results = json.dumps({})
+
+        response_ptr = self.lib.check_variant(
+            self.state,
+            toggle_name.encode("utf-8"),
+            serialized_context.encode("utf-8"),
+            custom_strategy_results.encode("utf-8"),
+        )
+        with self.materialize_pointer(response_ptr, Variant) as response:
+            if response.status_code == StatusCode.ERROR:
+                raise YggdrasilError(response.error_message)
+            return response.value


### PR DESCRIPTION
Brings the Python engine back to a working state and does some sanity clean ups

- Yggdrasil FFI function names have changed, this updates those to the new names
- Resolves the binary from ./lib, where it's expected to be for a production system + a build script to make that a bit easier to work with
- Adds typings to the public API
- Makes errors bubble
- Fixes a few leaks - we now free all the pointers correctly,