### PR TITLE
fix: stop hostname tests from flaking

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -33,6 +33,7 @@ async-std = "1.0.1"
 async-std-test = "0.0.4"
 criterion = "0.5.1"
 proptest = "1.2.0"
+serial_test = "3.1.1"
 
 [[bench]]
 name = "benchmark"

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -1078,9 +1078,12 @@ mod tests {
 
     #[cfg(feature = "hostname")]
     mod hostname_tests {
+        use serial_test::serial;
+
         use super::*;
 
         #[test]
+        #[serial]
         fn evaluates_host_name_constraint_correctly() {
             std::env::set_var("hostname", "DOS");
 
@@ -1092,6 +1095,7 @@ mod tests {
         }
 
         #[test]
+        #[serial]
         fn evaluates_host_name_to_false_when_missing_hostname_values() {
             std::env::set_var("hostname", "DOS");
 
@@ -1103,6 +1107,7 @@ mod tests {
         }
 
         #[test]
+        #[serial]
         fn hostname_constraint_ignores_casing() {
             std::env::set_var("hostname", "DaRWin");
 


### PR DESCRIPTION
Hostname tests require an env var to be set and then unset. But Rust runs tests in parallel with no isolation... yeah

This makes those flakey tests no longer flake