### PR TITLE
fix: include binary in wheel

### DIFF
--- a/python-engine/pyproject.toml
+++ b/python-engine/pyproject.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 packages = [
     { include = "yggdrasil_engine" }
 ]
+include = [
+    "yggdrasil_engine/lib/*"
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Adds the binary requires into the build for Python