### PR TITLE
feat(python): reject registration of custom strategies that don't quack like ducks

### DIFF
--- a/python-engine/yggdrasil_engine/custom_strategy.py
+++ b/python-engine/yggdrasil_engine/custom_strategy.py
@@ -1,5 +1,6 @@
 import json
 from typing import Dict
+import inspect
 
 _STANDARD_STRATEGIES = [
     "default",
@@ -41,6 +42,14 @@ class CustomStrategyHandler:
     def register_custom_strategies(self, custom_strategies: Dict[str, any]):
         for strategy_name, strategy in custom_strategies.items():
             if hasattr(strategy, "apply"):
+                apply_method = strategy.apply
+                signature = inspect.signature(apply_method)
+                parameters = list(signature.parameters)
+                if len(parameters) != 2:
+                    raise ValueError(
+                        f"Custom strategy '{strategy_name}' does not have an apply method "
+                        f"with exactly two parameters. Found {len(parameters)}."
+                    )
                 self.strategy_implementations[strategy_name] = strategy
             else:
                 raise ValueError(


### PR DESCRIPTION
This adds a little more validation to the objects passed to the register strategy hook in Python. I've put this in place because the legacy custom strategies in the Python SDK register like this:

``` python
{
  "some-strategy": CustomStrategy
}
```

whereas, the Yggdrasil engine wants them like this:

``` python
{
  "some-strategy": CustomStrategy()
}
```
Python is spectacularly unhelpful here, and the error message you get points out that you're missing a parameter (`self`, in this case). So this moves the check from runtime to registration time so that end users will get this pointed out in testing rather than at runtime

Apparently that's a subtle enough difference that you can lose 20 minutes debugging tests so now I'm validating in anger