### PR TITLE
fix: correct gem name for aarch64

### DIFF
--- a/.github/workflows/publish-ruby.yaml
+++ b/.github/workflows/publish-ruby.yaml
@@ -12,7 +12,7 @@ jobs:
           - binary: libyggdrasilffi_x86_64.so
             platform: x86_64-linux
           - binary: libyggdrasilffi_arm64.so
-            platform: arm-linux
+            platform: aarch64-linux
           - binary: libyggdrasilffi_x86_64-musl.so
             platform: x86_64-linux-musl
           - binary: libyggdrasilffi_arm64-musl.so

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'


### PR DESCRIPTION
Turns out arm doesn't actually resolve correctly on arm64