### PR TITLE
chore: extend compatbility to linux x86 ffi layer

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+image = "quay.io/pypa/manylinux2014_x86_64"


### PR DESCRIPTION
Moves cross to build in a container that supports GLIBC 2.17 for x86, which is the requirement for manylinux2014