### PR TITLE
Problem loading yggdrasilffi.dll on Windows

### DIFF
--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -18,7 +18,7 @@ def _get_binary_path():
     elif system == "Darwin":
         return os.path.join(lib_dir, "libyggdrasilffi.dylib")
     elif system == "Windows":
-        return os.path.join(lib_dir, "yggdrasilffi.so.dll")
+        return os.path.join(lib_dir, "yggdrasilffi.dll")
     else:
         raise RuntimeError(f"Unsupported operating system: {system}")
 


### PR DESCRIPTION
Rename the Windows Yggdrasil DLL from `yggdrasilffi.so.dll` to `yggdrasilffi.dll`.

I think the DLL file name should be without the `.so` part on Windows.

Problem encountered with UnleashClient 6.0.1 on Windows 11 with Python 3.12.7. 

The Unleash client tries to load the file 
`<virtual environment>\Lib\site-packages\yggdrasil_engine\lib\yggdrasilffi.so.dll` 
but on the disk is 
`<virtual environment>\Lib\site-packages\yggdrasil_engine\lib\yggdrasilffi.dll` 
