### PR TITLE
fix: support for utf-8 chars on win

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Unleash/client-specification
-          ref: v5.1.0
+          ref: v5.1.9
           path: client-specification
 
       - name: Set up .NET

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.1.0
+          ref: v5.1.9
           path: client-specification
 
       - name: Setup Java

--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Unleash/client-specification
-          ref: v5.1.0
+          ref: v5.1.9
           path: client-specification
 
       - name: Run e2e tests

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.1.7
+          ref: v5.1.9
           path: client-specification
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy enough - run `cargo build --release` from the root of the project. You'll n
 
 To run the client specs, you'll first need to clone them:
 
-`git clone --depth 5 --branch v5.1.0 https://github.com/Unleash/client-specification.git client-specification`
+`git clone --depth 5 --branch v5.1.9 https://github.com/Unleash/client-specification.git client-specification`
 
 ## Testing
 

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -12,19 +12,19 @@ internal static class FFI
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr get_metrics(IntPtr ptr);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr take_state(IntPtr ptr, string json);
+    private static extern IntPtr take_state(IntPtr ptr, byte[] json);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr check_enabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
+    private static extern IntPtr check_enabled(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr check_variant(IntPtr ptr, string toggle_name, string context, string customStrategyResults);
+    private static extern IntPtr check_variant(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
     private static extern void free_response(IntPtr ptr);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr count_toggle(IntPtr ptr, string toggle_name, bool enabled);
+    private static extern IntPtr count_toggle(IntPtr ptr, byte[] toggle_name, bool enabled);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr count_variant(IntPtr ptr, string toggle_name, string variant_name);
+    private static extern IntPtr count_variant(IntPtr ptr, byte[] toggle_name, byte[] variant_name);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr should_emit_impression_event(IntPtr ptr, string toggle_name);
+    private static extern IntPtr should_emit_impression_event(IntPtr ptr, byte[] toggle_name);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
     private static extern IntPtr built_in_strategies(IntPtr ptr);
     [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
@@ -47,7 +47,7 @@ internal static class FFI
 
     public static IntPtr TakeState(IntPtr ptr, string json)
     {
-        return take_state(ptr, json);
+        return take_state(ptr, ToUtf8Bytes(json));
     }
 
     public static IntPtr CheckEnabled(
@@ -57,7 +57,7 @@ internal static class FFI
         string customStrategyResults
     )
     {
-        return check_enabled(ptr, toggle_name, context, customStrategyResults);
+        return check_enabled(ptr, ToUtf8Bytes(toggle_name), ToUtf8Bytes(context), ToUtf8Bytes(customStrategyResults));
     }
 
     public static IntPtr CheckVariant(
@@ -67,7 +67,7 @@ internal static class FFI
         string customStrategyResults
     )
     {
-        return check_variant(ptr, toggle_name, context, customStrategyResults);
+        return check_variant(ptr, ToUtf8Bytes(toggle_name), ToUtf8Bytes(context), ToUtf8Bytes(customStrategyResults));
     }
 
     public static void FreeResponse(IntPtr ptr)
@@ -77,17 +77,17 @@ internal static class FFI
 
     public static IntPtr CountToggle(IntPtr ptr, string toggle_name, bool enabled)
     {
-        return count_toggle(ptr, toggle_name, enabled);
+        return count_toggle(ptr, ToUtf8Bytes(toggle_name), enabled);
     }
 
     public static IntPtr CountVariant(IntPtr ptr, string toggle_name, string variant_name)
     {
-        return count_variant(ptr, toggle_name, variant_name);
+        return count_variant(ptr, ToUtf8Bytes(toggle_name), ToUtf8Bytes(variant_name));
     }
 
     public static IntPtr ShouldEmitImpressionEvent(IntPtr ptr, string toggle_name)
     {
-        return should_emit_impression_event(ptr, toggle_name);
+        return should_emit_impression_event(ptr, ToUtf8Bytes(toggle_name));
     }
 
     public static IntPtr BuiltInStrategies(IntPtr ptr)
@@ -98,5 +98,17 @@ internal static class FFI
     public static IntPtr ListKnownToggles(IntPtr ptr)
     {
         return list_known_toggles(ptr);
+    }
+
+    /// <summary>
+    /// Converts a string to a UTF-8 encoded null-terminated byte array.
+    /// </summary>
+    /// <param name="input">The string to convert.</param>
+    /// <returns>A UTF-8 encoded null-terminated byte array.</returns>
+    private static byte[] ToUtf8Bytes(string input)
+    {
+        byte[] utf8Bytes = System.Text.Encoding.UTF8.GetBytes(input);
+        Array.Resize(ref utf8Bytes, utf8Bytes.Length + 1);
+        return utf8Bytes;
     }
 }

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -28,7 +28,7 @@ use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
-pub const SUPPORTED_SPEC_VERSION: &str = "5.1.0";
+pub const SUPPORTED_SPEC_VERSION: &str = "5.1.9";
 const VARIANT_NORMALIZATION_SEED: u32 = 86028157;
 
 pub struct CompiledToggle {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3110/net-sdk-utf-8-scandinavian-character-issue

Adds support for flag names with valid UTF-8 characters like `ø` when running on Windows.