### PR TITLE
chore: update to most recent unleash-types

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -8,32 +8,32 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.99"
+serde_json = "1.0.135"
 murmur3 = "0.5.2"
-ipnet = "2.8.0"
+ipnet = "2.10.1"
 rand = "0.8.5"
-pest = "2.0"
-pest_derive = "2.0"
-lazy_static = "1.4.0"
-semver = "1.0.17"
+pest = "2.7.15"
+pest_derive = "2.7.15"
+lazy_static = "1.5.0"
+semver = "1.0.24"
 convert_case = "0.6.0"
-unleash-types = "0.14.0"
-chrono = "0.4.38"
+unleash-types = "0.15.1"
+chrono = "0.4.39"
 dashmap = "6.1.0"
 hostname = { version = "0.4.0", optional = true }
-ipnetwork = "0.20.0"
+ipnetwork = "0.21.0"
 
 [dependencies.serde]
 features = ["derive"]
 version = "1.0"
 
 [dev-dependencies]
-test-case = "3.1.0"
-async-std = "1.0.1"
+test-case = "3.3.1"
+async-std = "1.13.0"
 async-std-test = "0.0.4"
 criterion = "0.5.1"
-proptest = "1.2.0"
-serial_test = "3.1.1"
+proptest = "1.6.0"
+serial_test = "3.2.0"
 
 [[bench]]
 name = "benchmark"

--- a/yggdrasilffi/Cargo.toml
+++ b/yggdrasilffi/Cargo.toml
@@ -12,7 +12,7 @@ name = "yggdrasilffi"
 
 [dependencies]
 libc = "0.2"
-serde_json = "1.0.68"
-serde = { version = "1.0.68", features = ["derive"] }
-unleash-types = "0.14.0"
+serde_json = "1.0.135"
+serde = { version = "1.0.217", features = ["derive"] }
+unleash-types = "0.15.3"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -477,6 +477,7 @@ mod tests {
             query: None,
             segments: None,
             version: 2,
+            meta: None,
         };
 
         unsafe {
@@ -598,6 +599,7 @@ mod tests {
             }],
             query: None,
             segments: None,
+            meta: None,
             version: 2,
         };
 
@@ -654,6 +656,7 @@ mod tests {
             ],
             query: None,
             segments: None,
+            meta: None,
             version: 2,
         };
 

--- a/yggdrasilwasm/Cargo.toml
+++ b/yggdrasilwasm/Cargo.toml
@@ -15,7 +15,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-unleash-types = "0.14.0"
+unleash-types = "0.15.3"
 unleash-yggdrasil = {path = "../unleash-yggdrasil"}
 getrandom = { version = "0.2", features = ["js"] }
 
@@ -23,10 +23,10 @@ getrandom = { version = "0.2", features = ["js"] }
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
-serde = { version = "1.0.190", features = ["derive"] }
-serde-wasm-bindgen = "0.6.1"
+serde = { version = "1.0.217", features = ["derive"] }
+serde-wasm-bindgen = "0.6.5"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
In order for Edge to work with deltas we need yggdrasil to also use most recent unleash-types.