### PR TITLE
chore: include ruby/windows build for modern windows

### DIFF
--- a/.github/workflows/publish-ruby.yaml
+++ b/.github/workflows/publish-ruby.yaml
@@ -19,6 +19,8 @@ jobs:
             platform: aarch64-linux-musl
           - binary: yggdrasilffi_x86_64.dll
             platform: x64-mingw32
+          - binary: yggdrasilffi_x86_64.dll
+            platform: x64-mingw32-ucrt            
           - binary: yggdrasilffi_arm64.dll
             platform: arm64-mingw32
           - binary: libyggdrasilffi_x86_64.dylib


### PR DESCRIPTION
Adds a build for Windows that works on Windows 10 and above