### PR TITLE
chore: bump unleash-types version

### DIFF
--- a/unleash-yggdrasil/Cargo.toml
+++ b/unleash-yggdrasil/Cargo.toml
@@ -17,7 +17,7 @@ pest_derive = "2.7.15"
 lazy_static = "1.5.0"
 semver = "1.0.24"
 convert_case = "0.6.0"
-unleash-types = "0.15.1"
+unleash-types = "0.15.3"
 chrono = "0.4.39"
 dashmap = "6.1.0"
 hostname = { version = "0.4.0", optional = true }


### PR DESCRIPTION
Bumping unleash-types from 0.15.1 to 0.15.3.