### PR TITLE
chore(ruby): support windows arch that identifies as x64 or x86_64

### DIFF
--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -22,7 +22,7 @@ def platform_specific_lib
   end
 
   arch_suffix = case cpu
-  when /x86_64/
+  when /x86_64|x64/
     'x86_64'
   when /arm|aarch64/
     'arm64'

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'


### PR DESCRIPTION
Some Ruby VMs on Windows identify as x64 and not x86_64. This helps Yggdrasil correctly identify that and load the correct binary 