### PR TITLE
chore(java): rework jar publish names to be compatible with maven os detector

### DIFF
--- a/java-engine/build.gradle.kts
+++ b/java-engine/build.gradle.kts
@@ -86,7 +86,7 @@ val platformToBinaryMap = mapOf(
     "linux-aarch_64" to "libyggdrasilffi_arm64.so",
     "linux-x86_64-alpine" to "libyggdrasilffi_x86_64-musl.so",
     "linux-aarch_64-alpine" to "libyggdrasilffi_arm64-musl.so",
-    "windows-x86_64" to "yggdrasilffi_x64.dll",
+    "windows-x86_64" to "yggdrasilffi_x86_64.dll",
     "windows-aarch_64" to "yggdrasilffi_arm64.dll",
     "osx-x86_64" to "libyggdrasilffi_x86_64.dylib",
     "osx-aarch_64" to "libyggdrasilffi_arm64.dylib"

--- a/java-engine/build.gradle.kts
+++ b/java-engine/build.gradle.kts
@@ -82,14 +82,14 @@ tasks.named<Test>("test") {
 }
 
 val platformToBinaryMap = mapOf(
-    "x86_64-linux" to "libyggdrasilffi_x86_64.so",
-    "arm-linux" to "libyggdrasilffi_arm64.so",
-    "x86_64-linux-musl" to "libyggdrasilffi_x86_64-musl.so",
-    "aarch64-linux-musl" to "libyggdrasilffi_arm64-musl.so",
-    "x64-mingw32" to "yggdrasilffi_x64.dll",
-    "arm64-mingw32" to "yggdrasilffi_arm64.dll",
-    "x86_64-darwin" to "libyggdrasilffi_x86_64.dylib",
-    "arm64-darwin" to "libyggdrasilffi_arm64.dylib"
+    "linux-x86_64" to "libyggdrasilffi_x86_64.so",
+    "linux-aarch_64" to "libyggdrasilffi_arm64.so",
+    "linux-x86_64-alpine" to "libyggdrasilffi_x86_64-musl.so",
+    "linux-aarch_64-alpine" to "libyggdrasilffi_arm64-musl.so",
+    "windows-x86_64" to "yggdrasilffi_x64.dll",
+    "windows-aarch_64" to "yggdrasilffi_arm64.dll",
+    "osx-x86_64" to "libyggdrasilffi_x86_64.dylib",
+    "osx-aarch_64" to "libyggdrasilffi_arm64.dylib"
 )
 
 

--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.14.1
-version=0.1.0-alpha.11
+version=0.1.0-alpha.12

--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.14.1
-version=0.1.0-alpha.10
+version=0.1.0-alpha.11

--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.14.1
-version=0.1.0-alpha.9
+version=0.1.0-alpha.10

--- a/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
+++ b/java-engine/src/main/java/io/getunleash/engine/YggdrasilFFI.java
@@ -58,7 +58,7 @@ class YggdrasilFFI {
                 libName = "libyggdrasilffi_x86_64.dylib";
             }
         } else if (os.contains("win")) {
-            if (arch.equals("x86_64")) {
+            if (arch.equals("x86_64") || arch.contains("amd64")) {
                 libName = "yggdrasilffi_x86_64.dll";
             } else if (arch.equals("x86") || arch.equals("i386") || arch.equals("i686")) {
                 libName = "yggdrasilffi_i686.dll";


### PR DESCRIPTION
This changes the way artifact names are created for Java artifacts to be compatbile with the way [Maven OS Detector](https://github.com/trustin/os-maven-plugin) works