### PR TITLE
feat(java): expose core version in java engine layer

### DIFF
--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -9,7 +9,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.lang.System;
 
 interface UnleashFFI extends Library {
@@ -93,12 +94,15 @@ class NativeLoader {
             throw new UnsupportedOperationException("Unsupported operating system: " + os + ", architecture: " + arch);
         }
 
+        Map<String, Object> options = new HashMap<>();
+        options.put(Library.OPTION_FUNCTION_MAPPER, new CamelToSnakeMapper());
+        options.put(Library.OPTION_STRING_ENCODING, "UTF-8");
+
         try {
             // Extract and load the native library from the JAR
             Path tempLib = extractLibraryFromJar(libName);
             System.load(tempLib.toAbsolutePath().toString());
-            return Native.load(tempLib.toAbsolutePath().toString(), UnleashFFI.class,
-                    Collections.singletonMap(Library.OPTION_FUNCTION_MAPPER, new CamelToSnakeMapper()));
+            return Native.load(tempLib.toAbsolutePath().toString(), UnleashFFI.class, options);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load native library", e);
         }

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -38,8 +38,14 @@ interface UnleashFFI extends Library {
 
     Pointer listKnownToggles(Pointer ptr);
 
+    Pointer getCoreVersion();
+
     static UnleashFFI getInstance() {
         return NativeLoader.NATIVE_INTERFACE;
+    }
+
+    static Pointer getYggdrasilCoreVersion() {
+        return NativeLoader.NATIVE_INTERFACE.getCoreVersion();
     }
 }
 

--- a/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
+++ b/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
@@ -141,6 +141,11 @@ public class UnleashEngine {
         return response.getValue();
     }
 
+    public static String getCoreVersion() {
+        Pointer versionPointer = UnleashFFI.getYggdrasilCoreVersion();
+        return versionPointer.getString(0);
+    }
+
     /** Handle reading from a pointer into a String and mapping it to an object */
     private <T> T read(Pointer pointer, TypeReference<T> clazz) {
         try {

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -285,6 +285,14 @@ class UnleashEngineTest {
         Mockito.verify(ffiMock).freeEngine(Mockito.any());
     }
 
+    @Test
+    void testCoreVersionIsRetrieved() {
+        String coreVersion = UnleashEngine.getCoreVersion();
+        assertNotNull(coreVersion);
+        // check that it contains two dots, close enough for a quick and dirty but stable semver check
+        assertTrue(coreVersion.split("\\.").length >= 3);
+    }
+
     private static Stream<Arguments> customStrategiesInput() {
         Context oneYesContext = new Context();
         oneYesContext.setProperties(mapOf("one", "yes"));

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -31,6 +31,7 @@ pub type CompiledState = HashMap<String, CompiledToggle>;
 
 pub const SUPPORTED_SPEC_VERSION: &str = "5.1.9";
 const VARIANT_NORMALIZATION_SEED: u32 = 86028157;
+pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub struct CompiledToggle {
     pub name: String,


### PR DESCRIPTION
Exposes the Yggdrasil version in the Java layer so we can always know what binary the Java engine is shipped with. Generally useful for other engines too