### PR TITLE
fix(java): java engine now passes UTF-8 encoded strings correctly on Windows

### DIFF
--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
-yggdrasilCoreVersion=0.14.1
-version=0.1.0-alpha.12
+yggdrasilCoreVersion=0.14.6
+version=0.1.0-alpha.15

--- a/java-engine/src/main/java/io/getunleash/engine/CamelToSnakeMapper.java
+++ b/java-engine/src/main/java/io/getunleash/engine/CamelToSnakeMapper.java
@@ -8,10 +8,13 @@ import com.sun.jna.NativeLibrary;
 class CamelToSnakeMapper implements FunctionMapper {
     @Override
     public String getFunctionName(NativeLibrary library, Method method) {
-        String methodName = method.getName();
+        return convertToSnake(method.getName());
+    }
+
+    String convertToSnake(String inputName) {
         StringBuilder snakeCaseName = new StringBuilder();
 
-        for (char c : methodName.toCharArray()) {
+        for (char c : inputName.toCharArray()) {
             if (Character.isUpperCase(c)) {
                 snakeCaseName.append('_').append(Character.toLowerCase(c));
             } else {

--- a/java-engine/src/main/java/io/getunleash/engine/FeatureDef.java
+++ b/java-engine/src/main/java/io/getunleash/engine/FeatureDef.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-class FeatureDef {
+public class FeatureDef {
     private final String name;
     private final Optional<String> type;
     private final String project;

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -19,19 +19,19 @@ interface UnleashFFI extends Library {
 
     void freeEngine(Pointer ptr);
 
-    Pointer takeState(Pointer ptr, String toggles);
+    Pointer takeState(Pointer ptr, Pointer toggles);
 
-    Pointer checkEnabled(Pointer ptr, String name, String context, String customStrategyResults);
+    Pointer checkEnabled(Pointer ptr, Pointer name, Pointer context, Pointer customStrategyResults);
 
-    Pointer checkVariant(Pointer ptr, String name, String context, String customStrategyResults);
+    Pointer checkVariant(Pointer ptr, Pointer name, Pointer context, Pointer customStrategyResults);
 
-    void countToggle(Pointer ptr, String name, boolean enabled);
+    void countToggle(Pointer ptr, Pointer name, boolean enabled);
 
-    void countVariant(Pointer ptr, String name, String variantName);
+    void countVariant(Pointer ptr, Pointer name, Pointer variantName);
 
     Pointer getMetrics(Pointer ptr);
 
-    Pointer shouldEmitImpressionEvent(Pointer ptr, String name);
+    Pointer shouldEmitImpressionEvent(Pointer ptr, Pointer name);
 
     Pointer builtInStrategies();
 

--- a/java-engine/src/main/java/io/getunleash/engine/YggResponse.java
+++ b/java-engine/src/main/java/io/getunleash/engine/YggResponse.java
@@ -19,7 +19,7 @@ class YggResponse<T> {
     }
 
     boolean isValid() {
-        return StatusCode.Ok.equals(this.statusCode);
+        return !StatusCode.Error.equals(this.statusCode);
     }
 
     public T getValue() throws YggdrasilError {

--- a/java-engine/src/test/java/io/getunleash/engine/CamelToSnakeMapperTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/CamelToSnakeMapperTest.java
@@ -1,0 +1,19 @@
+package io.getunleash.engine;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CamelToSnakeMapperTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "snakesAreTotallyCoolerThanCamels, snakes_are_totally_cooler_than_camels",
+            "single, single",
+            "somethingWithASingleCharacter, something_with_a_single_character",
+    })
+    void testComplexSnakeNameIsConvertedToCamel(String input, String expected) {
+        CamelToSnakeMapper mapper = new CamelToSnakeMapper();
+        String snakeName = mapper.convertToSnake(input);
+        assert (snakeName.equals(expected));
+    }
+}

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -62,7 +62,7 @@ class UnleashEngineTest {
     }
 
     @Test
-    void testTakeState() throws YggdrasilInvalidInputException {
+    void testTakeState() throws YggdrasilInvalidInputException, YggdrasilError {
         engine.takeState(simpleFeatures);
     }
 


### PR DESCRIPTION
This forces the Java engine to encode its strings as UTF-8 pointers rather than whatever the JVM feels like (thank you, Windows, very nice). To figure out what was going on here, there's some redesign to the way the pointers are materialized so that they bubble the Rust errors to the caller