### PR TITLE
Feat/ffi layers

### DIFF
--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -58,6 +58,7 @@ class YggdrasilEngine
   attach_function :free_engine, [:pointer], :void
 
   attach_function :take_state, %i[pointer string], :pointer
+  attach_function :hydrate_data, %i[pointer string], :pointer 
   attach_function :check_enabled, %i[pointer string string string], :pointer
   attach_function :check_variant, %i[pointer string string string], :pointer
   attach_function :get_metrics, [:pointer], :pointer
@@ -80,7 +81,7 @@ class YggdrasilEngine
 
   def take_state(toggles)
     @custom_strategy_handler.update_strategies(toggles)
-    response_ptr = YggdrasilEngine.take_state(@engine, toggles)
+    response_ptr = YggdrasilEngine.hydrate_data(@engine, toggles)
     take_toggles_response = JSON.parse(response_ptr.read_string, symbolize_names: true)
     YggdrasilEngine.free_response(response_ptr)
   end

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency "ffi", "~> 1.16.3"
   s.platform = target_platform.call
-  s.metadata["yggdrasil_core_version"] = '0.14.2'
+  s.metadata["yggdrasil_core_version"] = '0.15.1'
 end

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -248,10 +248,10 @@ pub struct ResolvedToggle {
 }
 
 impl EngineState {
-    pub fn take_delta(&mut self, delta: &ClientFeaturesDelta) {
+    pub fn take_delta(&mut self, delta: &ClientFeaturesDelta) -> Option<Vec<EvalWarning>> {
         let mut new_state = self.previous_state.clone();
         new_state.modify_in_place(delta);
-        self.take_state(new_state);
+        self.take_state(new_state)
     }
 
     fn get_toggle(&self, name: &str) -> Option<&CompiledToggle> {

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -7,7 +7,10 @@ use std::{
 
 use libc::c_void;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use unleash_types::{client_features::ClientFeatures, client_metrics::MetricBucket};
+use unleash_types::{
+    client_features::{ClientFeatures, ClientFeaturesDelta},
+    client_metrics::MetricBucket,
+};
 use unleash_yggdrasil::{
     Context, EngineState, EvalWarning, ExtendedVariantDef, ToggleDefinition, CORE_VERSION,
 };
@@ -29,6 +32,13 @@ enum ResponseCode {
     Error = -2,
     NotFound = -1,
     Ok = 1,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum UpdateMessage {
+    FullResponse(ClientFeatures),
+    PartialUpdate(ClientFeaturesDelta),
 }
 
 impl<T> From<Result<Option<T>, FFIError>> for Response<T> {
@@ -178,6 +188,36 @@ pub unsafe extern "C" fn take_state(
             Err(FFIError::PartialUpdate(warnings))
         } else {
             Ok(Some(()))
+        }
+    })();
+
+    result_to_json_ptr(result)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn take_delta_update(
+    engine_ptr: *mut c_void,
+    json_ptr: *const c_char,
+) -> *const c_char {
+    let result: Result<Option<()>, FFIError> = (|| {
+        let engine = get_engine(engine_ptr)?;
+        let update_message: UpdateMessage = get_json(json_ptr)?;
+
+        match update_message {
+            UpdateMessage::FullResponse(features_message) => {
+                if let Some(warnings) = engine.take_state(features_message) {
+                    Err(FFIError::PartialUpdate(warnings))
+                } else {
+                    Ok(Some(()))
+                }
+            }
+            UpdateMessage::PartialUpdate(delta_message) => {
+                if let Some(warnings) = engine.take_delta(&delta_message) {
+                    Err(FFIError::PartialUpdate(warnings))
+                } else {
+                    Ok(Some(()))
+                }
+            }
         }
     })();
 

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -194,8 +194,18 @@ pub unsafe extern "C" fn take_state(
     result_to_json_ptr(result)
 }
 
+/// Takes a JSON string representing either a set of toggles or a series of events representing updates to client features
+/// Returns a JSON encoded response object specifying whether the update was successful or not. The caller is responsible
+/// for freeing this response object.
+///
+/// # Safety
+///
+/// The caller is responsible for ensuring all arguments are valid pointers.
+/// Null pointers will result in an error message being returned to the caller,
+/// but any invalid pointers will result in undefined behavior.
+/// These pointers should not be dropped for the lifetime of this function call.
 #[no_mangle]
-pub unsafe extern "C" fn take_delta_update(
+pub unsafe extern "C" fn hydrate_data(
     engine_ptr: *mut c_void,
     json_ptr: *const c_char,
 ) -> *const c_char {


### PR DESCRIPTION
This PR adds the glue layer for Ruby SDK and adds a new main entrypoint called `hydrate_data` that will identify whether the data input is a client features API response or a delta API response.