### PR TITLE
fix(ruby): bump yggdrasil core version to a version that actually exists

### DIFF
--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency "ffi", "~> 1.16.3"
   s.platform = target_platform.call
-  s.metadata["yggdrasil_core_version"] = '0.15.1'
+  s.metadata["yggdrasil_core_version"] = '0.16.0'
 end


### PR DESCRIPTION
Bump the Yggdrasil version referenced by Ruby so that we can publish