### PR TITLE
chore: remove JRuby build support for 9.2, this isn't supported by the SDK and fails the github runners

### DIFF
--- a/.github/workflows/publish-ruby.yaml
+++ b/.github/workflows/publish-ruby.yaml
@@ -87,8 +87,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - java: 8
-            ruby: jruby-9.2
           - java: 11
             ruby: jruby-9.3
           - java: 17


### PR DESCRIPTION
Does what it says on the tin