### PR TITLE
chore: optimizations to core layer

### DIFF
--- a/unleash-yggdrasil/benches/benchmark.rs
+++ b/unleash-yggdrasil/benches/benchmark.rs
@@ -10,18 +10,17 @@ fn is_enabled(engine: &EngineState, toggle_name: &str, context: &Context) {
 
 fn benchmark_with_no_strategy(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine
-        .take_state(ClientFeatures {
-            version: 2,
-            features: vec![ClientFeature {
-                name: "test".into(),
-                enabled: true,
-                ..ClientFeature::default()
-            }],
-            segments: None,
-            query: None,
-        })
-        .unwrap();
+    engine.take_state(ClientFeatures {
+        version: 2,
+        features: vec![ClientFeature {
+            name: "test".into(),
+            enabled: true,
+            ..ClientFeature::default()
+        }],
+        segments: None,
+        query: None,
+        meta: None,
+    });
     let context = Context {
         user_id: None,
         session_id: None,
@@ -63,8 +62,8 @@ fn benchmark_with_single_constraint(c: &mut Criterion) {
             }],
             segments: None,
             query: None,
-        })
-        .unwrap();
+            meta: None,
+        });
     let context = Context {
         user_id: Some("7".into()),
         session_id: None,
@@ -116,8 +115,8 @@ fn benchmark_with_two_constraints(c: &mut Criterion) {
             }],
             segments: None,
             query: None,
-        })
-        .unwrap();
+            meta: None,
+        });
     let context = Context {
         user_id: Some("7".into()),
         session_id: None,
@@ -168,6 +167,7 @@ fn benchmark_engine_ingestion(c: &mut Criterion) {
         }],
         segments: None,
         query: None,
+        meta: None,
     };
     c.bench_function("engine ingestion", |b| {
         b.iter(|| engine.take_state(black_box(state.clone())))

--- a/unleash-yggdrasil/src/state.rs
+++ b/unleash-yggdrasil/src/state.rs
@@ -24,10 +24,7 @@ impl EnrichedContext {
             session_id: context.session_id.clone(),
             environment: context.environment.clone(),
             app_name: context.app_name.clone(),
-            current_time: context
-                .current_time
-                .clone()
-                .or_else(|| Some(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string())),
+            current_time: context.current_time.clone(),
             remote_address: context.remote_address.clone(),
             properties: context.properties,
             external_results,
@@ -40,50 +37,4 @@ impl EnrichedContext {
 pub enum SdkError {
     StrategyEvaluationError,
     StrategyParseError(String),
-}
-
-#[cfg(test)]
-mod test {
-    use crate::strategy_parsing::compile_rule;
-
-    use super::*;
-    use unleash_types::client_features::Context;
-
-    #[test]
-    fn converting_a_context_to_enriched_context_assumes_now_for_time_if_not_set() {
-        let context = Context::default();
-        let enriched_context = EnrichedContext::from(context, "test".into(), None);
-        chrono::DateTime::parse_from_rfc3339(
-            &enriched_context
-                .current_time
-                .clone()
-                .expect("current_time should be set"),
-        )
-        .expect("cannot parse retrieved dates");
-    }
-
-    #[test]
-    fn converting_a_context_to_enriched_context_leaves_current_time_alone_if_set() {
-        let context = Context {
-            current_time: Some("2020-01-01T00:00:00Z".into()),
-            ..Context::default()
-        };
-        let enriched_context = EnrichedContext::from(context, "test".into(), None);
-        assert_eq!(
-            enriched_context
-                .current_time
-                .expect("current_time should be set"),
-            "2020-01-01T00:00:00Z"
-        );
-    }
-
-    #[test]
-    fn assumed_current_time_works_correctly_in_a_constraint() {
-        let rule_text = "current_time > 2023-10-13T10:19:22Z";
-        let rule = compile_rule(rule_text).unwrap();
-        let context = Context::default();
-        let enriched_context = EnrichedContext::from(context, "test".into(), None);
-
-        assert!(rule(&enriched_context));
-    }
 }


### PR DESCRIPTION
1) Brings the benchmark tests back to green.

2) Moves datetime fallback out of the `is_enabled` function and into the handling code for getting context values in the rule engine. This means that toggles that don't need current time don't incur the hit of resolving the current date. This improves time for basic `is_enabled` from `690.26ns` to `62.764ns` for a cool -91.017% speed improvement