### PR TITLE
fix(java): correctly detect musl systems and load the appropriate binaries

### DIFF
--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.16.1
-version=0.1.0-alpha.16
+version=0.1.0-alpha.17


### PR DESCRIPTION
The JVM does not list alpine correctly so we have to do a slightly more complex dance to resolve musl systems

This is precisely halfway between a dirty hack and very elegant