### PR TITLE
feat: move state ingestion entry point

### DIFF
--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Unleash/client-specification
-          ref: v5.1.9
+          ref: v5.2.0
           path: client-specification
 
       - name: Run e2e tests

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.1.9
+          ref: v5.2.0
           path: client-specification
       - name: Run tests
         run: |

--- a/ruby-engine/lib/custom_strategy.rb
+++ b/ruby-engine/lib/custom_strategy.rb
@@ -18,7 +18,9 @@ class CustomStrategyHandler
     custom_strategies = {}
     parsed_json = JSON.parse(json_str)
 
-    parsed_json["features"].each do |feature|
+    features = extract_features parsed_json
+
+    features.each do |feature|
       toggle_name = feature["name"]
       strategies = feature["strategies"]
 
@@ -56,5 +58,25 @@ class CustomStrategyHandler
     end
 
     results
+  end
+
+  private
+
+  def extract_features(data)
+    return data["features"] if data.is_a?(Hash) && data.key?("features")
+
+    if data.is_a?(Hash) && data.key?("events")
+      features = []
+
+      hydration_events = data["events"].select { |e| e["type"] == "hydration" }
+      features.concat(hydration_events.flat_map { |e| e["features"] || [] })
+
+      feature_updated_events = data["events"].select { |e| e["type"] == "feature-updated" }
+      features.concat(feature_updated_events.map { |e| e["feature"] })
+
+      return features
+    end
+
+    []
   end
 end

--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -58,7 +58,6 @@ class YggdrasilEngine
   attach_function :free_engine, [:pointer], :void
 
   attach_function :take_state, %i[pointer string], :pointer
-  attach_function :hydrate_data, %i[pointer string], :pointer 
   attach_function :check_enabled, %i[pointer string string string], :pointer
   attach_function :check_variant, %i[pointer string string string], :pointer
   attach_function :get_metrics, [:pointer], :pointer
@@ -81,7 +80,7 @@ class YggdrasilEngine
 
   def take_state(toggles)
     @custom_strategy_handler.update_strategies(toggles)
-    response_ptr = YggdrasilEngine.hydrate_data(@engine, toggles)
+    response_ptr = YggdrasilEngine.take_state(@engine, toggles)
     take_toggles_response = JSON.parse(response_ptr.read_string, symbolize_names: true)
     YggdrasilEngine.free_response(response_ptr)
   end

--- a/ruby-engine/spec/yggdrasil_engine_spec.rb
+++ b/ruby-engine/spec/yggdrasil_engine_spec.rb
@@ -103,6 +103,15 @@ RSpec.describe YggdrasilEngine do
       toggles = yggdrasil_engine.list_known_toggles()
       expect(toggles.length).to eq(3)
     end
+
+    it 'should load delta format correctly' do
+      suite_path = File.join('../client-specification/specifications', '19-delta-api-hydration.json')
+      suite_data = JSON.parse(File.read(suite_path))
+
+      yggdrasil_engine.take_state(suite_data['state'].to_json)
+
+      # toggles = yggdrasil_engine.list_known_toggles()
+    end
   end
 end
 

--- a/unleash-yggdrasil/benches/benchmark.rs
+++ b/unleash-yggdrasil/benches/benchmark.rs
@@ -10,7 +10,7 @@ fn is_enabled(engine: &EngineState, toggle_name: &str, context: &Context) {
 
 fn benchmark_with_no_strategy(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
+    engine.apply_client_features(ClientFeatures {
         version: 2,
         features: vec![ClientFeature {
             name: "test".into(),
@@ -37,7 +37,7 @@ fn benchmark_with_no_strategy(c: &mut Criterion) {
 
 fn benchmark_with_single_constraint(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
+    engine.apply_client_features(ClientFeatures {
         version: 2,
         features: vec![ClientFeature {
             name: "test".into(),
@@ -79,7 +79,7 @@ fn benchmark_with_single_constraint(c: &mut Criterion) {
 
 fn benchmark_with_two_constraints(c: &mut Criterion) {
     let mut engine = EngineState::default();
-    engine.take_state(ClientFeatures {
+    engine.apply_client_features(ClientFeatures {
         version: 2,
         features: vec![ClientFeature {
             name: "test".into(),
@@ -168,7 +168,7 @@ fn benchmark_engine_ingestion(c: &mut Criterion) {
         meta: None,
     };
     c.bench_function("engine ingestion", |b| {
-        b.iter(|| engine.take_state(black_box(state.clone())))
+        b.iter(|| engine.apply_client_features(black_box(state.clone())))
     });
 }
 

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -844,6 +844,8 @@ mod test {
     #[test_case("16-strategy-variants.json"; "Strategy variants")]
     #[test_case("17-dependent-features.json"; "Dependent features")]
     #[test_case("18-utf8-flag-names.json"; "UTF-8 tests")]
+    #[test_case("19-delta-api-hydration.json"; "Delta hydration tests")]
+    #[test_case("20-delta-api-events.json"; "Delta events tests")]
 
     fn run_client_spec(spec_name: &str) {
         let spec = load_spec(spec_name);

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -29,7 +29,7 @@ use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
 pub type CompiledState = HashMap<String, CompiledToggle>;
 
-pub const SUPPORTED_SPEC_VERSION: &str = "5.1.9";
+pub const SUPPORTED_SPEC_VERSION: &str = "5.2.0";
 const VARIANT_NORMALIZATION_SEED: u32 = 86028157;
 pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -471,7 +471,8 @@ mod tests {
     use std::ffi::{CStr, CString};
 
     use unleash_types::client_features::{
-        ClientFeature, ClientFeatures, Strategy, Variant, WeightType,
+        ClientFeature, ClientFeatures, ClientFeaturesDelta, Constraint, DeltaEvent, Operator,
+        Segment, Strategy, Variant, WeightType,
     };
     use unleash_yggdrasil::{EngineState, ExtendedVariantDef, UpdateMessage};
 

--- a/yggdrasilwasm/src/lib.rs
+++ b/yggdrasilwasm/src/lib.rs
@@ -3,8 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::from_value;
 use std::collections::HashMap;
-use unleash_types::client_features::ClientFeatures;
-use unleash_yggdrasil::{Context, EngineState, ExtendedVariantDef};
+use unleash_yggdrasil::{Context, EngineState, ExtendedVariantDef, UpdateMessage};
 use wasm_bindgen::prelude::*;
 
 type CustomStrategyResults = HashMap<String, bool>;
@@ -38,7 +37,7 @@ impl Engine {
 
     #[wasm_bindgen(js_name = takeState)]
     pub fn take_state(&mut self, state: JsValue) -> JsValue {
-        let state: ClientFeatures = match from_value(state) {
+        let state: UpdateMessage = match from_value(state) {
             Ok(state) => state,
             Err(e) => {
                 let response = Response::<()> {


### PR DESCRIPTION
Move the check for whether the inputs to take_state are a clientFeatures object or a list of delta messages.

This is done for two reasons:

1) Consumers of take_state no longer need to know or care about what message they're handling, only that it will be handled
2) Tests can be run on the public API in Yggdrasil and that's the same public API that users will use