### PR TITLE
fix: support dotnet framework

### DIFF
--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -28,33 +28,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          binaries=("libyggdrasilffi_x86_64-musl.so dotnet-engine/runtimes/linux-musl-x64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64-musl.so dotnet-engine/runtimes/linux-musl-arm64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native libyggdrasilffi.so"
-                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native libyggdrasilffi.so"
-                    "yggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native yggdrasilffi.dll"
-                    "yggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native yggdrasilffi.dll"
-                    "yggdrasilffi_i686.dll dotnet-engine/runtimes/win-x86/native yggdrasilffi.dll"
-                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native libyggdrasilffi.dylib"
-                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native libyggdrasilffi.dylib")
+          binaries=("libyggdrasilffi_x86_64-musl.so dotnet-engine/runtimes/linux-musl-x64/native"
+                    "libyggdrasilffi_arm64-musl.so dotnet-engine/runtimes/linux-musl-arm64/native"
+                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native"
+                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native"
+                    "yggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native"
+                    "yggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native"
+                    "yggdrasilffi_i686.dll dotnet-engine/runtimes/win-x86/native"
+                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native"
+                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native")
 
           for binary in "${binaries[@]}"; do
             # Split each item into source (release name) and target path
             src_name=$(echo "$binary" | awk '{print $1}')
             target_path=$(echo "$binary" | awk '{print $2}')
-            binary_name=$(echo "$binary" | awk '{print $3}')
 
             echo "Downloading $src_name to $target_path..."
 
             mkdir -p "$target_path"
 
-            curl -L -o "$target_path/$binary_name" \
+            curl -L -o "$target_path/$src_name" \
               -H "Authorization: token $GITHUB_TOKEN" \
               "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
             echo "Downloaded from https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
 
-            if [ -f "$target_path/$binary_name" ]; then
+            if [ -f "$target_path/$src_name" ]; then
               echo "$src_name downloaded successfully to $target_path."
             else
               echo "Error: $src_name could not be downloaded to $target_path."

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -37,8 +37,6 @@ internal static class FFI
     private delegate IntPtr ShouldEmitImpressionEventDelegate(IntPtr ptr, byte[] toggle_name);
     private delegate IntPtr BuiltInStrategiesDelegate(IntPtr ptr);
     private delegate IntPtr ListKnownTogglesDelegate(IntPtr ptr);
-
-
     private static readonly NewEngineDelegate new_engine;
     private static readonly FreeEngineDelegate free_engine;
     private static readonly GetMetricsDelegate get_metrics;

--- a/dotnet-engine/Yggdrasil.Engine/FFI.cs
+++ b/dotnet-engine/Yggdrasil.Engine/FFI.cs
@@ -1,34 +1,56 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace Yggdrasil;
 
 internal static class FFI
 {
+    private static IntPtr _libHandle;
 
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr new_engine();
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern void free_engine(IntPtr ptr);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr get_metrics(IntPtr ptr);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr take_state(IntPtr ptr, byte[] json);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr check_enabled(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr check_variant(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern void free_response(IntPtr ptr);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr count_toggle(IntPtr ptr, byte[] toggle_name, bool enabled);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr count_variant(IntPtr ptr, byte[] toggle_name, byte[] variant_name);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr should_emit_impression_event(IntPtr ptr, byte[] toggle_name);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr built_in_strategies(IntPtr ptr);
-    [DllImport("yggdrasilffi", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
-    private static extern IntPtr list_known_toggles(IntPtr ptr);
+    static FFI()
+    {
+        _libHandle = NativeLibLoader.LoadNativeLibrary();
+
+        new_engine = Marshal.GetDelegateForFunctionPointer<NewEngineDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "new_engine"));
+        free_engine = Marshal.GetDelegateForFunctionPointer<FreeEngineDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "free_engine"));
+        get_metrics = Marshal.GetDelegateForFunctionPointer<GetMetricsDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "get_metrics"));
+        take_state = Marshal.GetDelegateForFunctionPointer<TakeStateDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "take_state"));
+        check_enabled = Marshal.GetDelegateForFunctionPointer<CheckEnabledDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "check_enabled"));
+        check_variant = Marshal.GetDelegateForFunctionPointer<CheckVariantDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "check_variant"));
+        free_response = Marshal.GetDelegateForFunctionPointer<FreeResponseDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "free_response"));
+        count_toggle = Marshal.GetDelegateForFunctionPointer<CountToggleDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "count_toggle"));
+        count_variant = Marshal.GetDelegateForFunctionPointer<CountVariantDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "count_variant"));
+        should_emit_impression_event = Marshal.GetDelegateForFunctionPointer<ShouldEmitImpressionEventDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "should_emit_impression_event"));
+        built_in_strategies = Marshal.GetDelegateForFunctionPointer<BuiltInStrategiesDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "built_in_strategies"));
+        list_known_toggles = Marshal.GetDelegateForFunctionPointer<ListKnownTogglesDelegate>(NativeLibLoader.LoadFunctionPointer(_libHandle, "list_known_toggles"));
+    }
+
+    private delegate IntPtr NewEngineDelegate();
+    private delegate void FreeEngineDelegate(IntPtr ptr);
+    private delegate IntPtr GetMetricsDelegate(IntPtr ptr);
+    private delegate IntPtr TakeStateDelegate(IntPtr ptr, byte[] json);
+    private delegate IntPtr CheckEnabledDelegate(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
+    private delegate IntPtr CheckVariantDelegate(IntPtr ptr, byte[] toggle_name, byte[] context, byte[] customStrategyResults);
+    private delegate void FreeResponseDelegate(IntPtr ptr);
+    private delegate IntPtr CountToggleDelegate(IntPtr ptr, byte[] toggle_name, bool enabled);
+    private delegate IntPtr CountVariantDelegate(IntPtr ptr, byte[] toggle_name, byte[] variant_name);
+    private delegate IntPtr ShouldEmitImpressionEventDelegate(IntPtr ptr, byte[] toggle_name);
+    private delegate IntPtr BuiltInStrategiesDelegate(IntPtr ptr);
+    private delegate IntPtr ListKnownTogglesDelegate(IntPtr ptr);
+
+
+    private static readonly NewEngineDelegate new_engine;
+    private static readonly FreeEngineDelegate free_engine;
+    private static readonly GetMetricsDelegate get_metrics;
+    private static readonly TakeStateDelegate take_state;
+    private static readonly CheckEnabledDelegate check_enabled;
+    private static readonly CheckVariantDelegate check_variant;
+    private static readonly FreeResponseDelegate free_response;
+    private static readonly CountToggleDelegate count_toggle;
+    private static readonly CountVariantDelegate count_variant;
+    private static readonly ShouldEmitImpressionEventDelegate should_emit_impression_event;
+    private static readonly BuiltInStrategiesDelegate built_in_strategies;
+    private static readonly ListKnownTogglesDelegate list_known_toggles;
 
     public static IntPtr NewEngine()
     {
@@ -50,22 +72,12 @@ internal static class FFI
         return take_state(ptr, ToUtf8Bytes(json));
     }
 
-    public static IntPtr CheckEnabled(
-        IntPtr ptr,
-        string toggle_name,
-        string context,
-        string customStrategyResults
-    )
+    public static IntPtr CheckEnabled(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
         return check_enabled(ptr, ToUtf8Bytes(toggle_name), ToUtf8Bytes(context), ToUtf8Bytes(customStrategyResults));
     }
 
-    public static IntPtr CheckVariant(
-        IntPtr ptr,
-        string toggle_name,
-        string context,
-        string customStrategyResults
-    )
+    public static IntPtr CheckVariant(IntPtr ptr, string toggle_name, string context, string customStrategyResults)
     {
         return check_variant(ptr, ToUtf8Bytes(toggle_name), ToUtf8Bytes(context), ToUtf8Bytes(customStrategyResults));
     }
@@ -100,11 +112,6 @@ internal static class FFI
         return list_known_toggles(ptr);
     }
 
-    /// <summary>
-    /// Converts a string to a UTF-8 encoded null-terminated byte array.
-    /// </summary>
-    /// <param name="input">The string to convert.</param>
-    /// <returns>A UTF-8 encoded null-terminated byte array.</returns>
     private static byte[] ToUtf8Bytes(string input)
     {
         byte[] utf8Bytes = System.Text.Encoding.UTF8.GetBytes(input);

--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -56,9 +56,6 @@ internal static class NativeLibLoader
             ? $"yggdrasilffi_{arch}.dll"
             : $"libyggdrasilffi_{arch}{libc}.{(os == "osx" ? "dylib" : "so")}";
 
-        Console.WriteLine($"[NativeLibLoader] Detected OS: {os}, Arch: {arch}, libc: {libc}");
-        Console.WriteLine($"[NativeLibLoader] Selected binary: {filename}");
-
         return filename;
     }
 

--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -112,31 +112,22 @@ internal static class NativeLibLoader
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
             return GetProcAddress(libHandle, functionName);
-        }
         else
-        {
             return dlsym(libHandle, functionName);
-        }
     }
 
     private static IntPtr LoadBinary(string libPath)
     {
-        var handle = IntPtr.Zero;
+        IntPtr handle;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
             handle = LoadWindowsLibrary(libPath);
-        }
         else
-        {
             handle = LoadUnixLibrary(libPath);
-        }
 
         if (handle == IntPtr.Zero)
-        {
             throw new DllNotFoundException($"Failed to load library from {libPath}");
-        }
+
         return handle;
     }
 
@@ -148,9 +139,7 @@ internal static class NativeLibLoader
         {
             var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
             if (loadMethod != null)
-            {
                 return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
-            }
         }
         return dlopen(libPath, RTLD_NOW);
     }
@@ -163,9 +152,7 @@ internal static class NativeLibLoader
         {
             var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
             if (loadMethod != null)
-            {
                 return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
-            }
         }
 
         return LoadLibrary(libPath);

--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+internal static class NativeLibLoader
+{
+    internal static IntPtr LoadNativeLibrary()
+    {
+        var libName = GetLibraryName();
+        var tempPath = Path.Combine(Path.GetTempPath(), libName);
+        var assembly = Assembly.GetExecutingAssembly();
+        var assemblyName = assembly.GetName().Name;
+
+        if (!File.Exists(tempPath))
+        {
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"{assemblyName}.{libName}"))
+            {
+                if (stream == null)
+                    throw new FileNotFoundException($"Embedded resource {libName} not found.");
+
+                using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
+                {
+                    stream.CopyTo(fileStream);
+                }
+            }
+        }
+
+        return LoadBinary(tempPath);
+    }
+
+    private static string GetLibraryName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "yggdrasilffi.dll";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return "libyggdrasilffi.so";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return "libyggdrasilffi.dylib";
+
+        throw new PlatformNotSupportedException("Unsupported OS");
+    }
+
+
+    internal static IntPtr LoadFunctionPointer(IntPtr libHandle, string functionName)
+    {
+        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        if (nativeLibraryType != null)
+        {
+            var getExportMethod = nativeLibraryType.GetMethod("GetExport", new[] { typeof(IntPtr), typeof(string) });
+            if (getExportMethod != null)
+            {
+                return (IntPtr)getExportMethod.Invoke(null, new object[] { libHandle, functionName });
+            }
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return GetProcAddress(libHandle, functionName);
+        }
+        else
+        {
+            return dlsym(libHandle, functionName);
+        }
+    }
+
+    private static IntPtr LoadBinary(string libPath)
+    {
+        var handle = IntPtr.Zero;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            handle = LoadWindowsLibrary(libPath);
+        }
+        else
+        {
+            handle = LoadUnixLibrary(libPath);
+        }
+
+        if (handle == IntPtr.Zero)
+        {
+            throw new DllNotFoundException($"Failed to load library from {libPath}");
+        }
+        return handle;
+    }
+
+    private static IntPtr LoadUnixLibrary(string libPath)
+    {
+        // Try NativeLibrary.Load (works on .NET Core 3+)
+        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        if (nativeLibraryType != null)
+        {
+            var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
+            if (loadMethod != null)
+            {
+                return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
+            }
+        }
+        return dlopen(libPath, RTLD_NOW);
+    }
+
+    private static IntPtr LoadWindowsLibrary(string libPath)
+    {
+        // Try NativeLibrary.Load (works on .NET Core 3+)
+        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        if (nativeLibraryType != null)
+        {
+            var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
+            if (loadMethod != null)
+            {
+                return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
+            }
+        }
+
+        return LoadLibrary(libPath);
+    }
+
+#if NETSTANDARD
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr LoadLibrary(string dllToLoad);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool FreeLibrary(IntPtr hModule);
+
+    [DllImport("libdl.so.2", EntryPoint = "dlopen")]
+    private static extern IntPtr dlopen(string filename, int flags);
+
+    [DllImport("libdl.so.2", EntryPoint = "dlclose")]
+    private static extern int dlclose(IntPtr handle);
+
+    private const int RTLD_NOW = 2;
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+
+    [DllImport("libdl.so.2", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+#endif
+}

--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -5,7 +5,7 @@ internal static class NativeLibLoader
 {
     internal static IntPtr LoadNativeLibrary()
     {
-        var libName = GetLibraryName();
+        var libName = GetBinaryName();
         var tempPath = Path.Combine(Path.GetTempPath(), libName);
         var assembly = Assembly.GetExecutingAssembly();
         var assemblyName = assembly.GetName().Name;
@@ -27,7 +27,7 @@ internal static class NativeLibLoader
         return LoadBinary(tempPath);
     }
 
-    private static string GetLibraryName()
+    private static string GetBinaryName()
     {
         string os, arch, libc = "";
 

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -37,21 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
-    <Content Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
-    <Content Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
+    <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" />
+    <!-- <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')" /> -->
+    <!-- <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')" /> -->
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- <ItemGroup>
     <None Include="../runtimes/win-x64/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-x64/native/" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi.dll')" />
     <None Include="../runtimes/win-arm64/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-arm64/native/" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi.dll')" />
     <None Include="../runtimes/win-x86/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-x86/native/" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi.dll')" />
@@ -61,5 +52,5 @@
     <None Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi.so" Pack="true" PackagePath="runtimes/linux-musl-arm64/native/" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi.so')" />
     <None Include="../runtimes/osx-x64/native/libyggdrasilffi.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi.dylib')" />
     <None Include="../runtimes/osx-arm64/native/libyggdrasilffi.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi.dylib')" />
-  </ItemGroup>
+  </ItemGroup> -->
 </Project>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -37,9 +37,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')" />
-    <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')" />
-    <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')" />
+    <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')">
+      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64.so</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')">
+      <LogicalName>Yggdrasil.Engine.yggdrasilffi_x86_64.dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')">
+      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64.dylib</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -37,20 +37,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" />
-    <!-- <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')" /> -->
-    <!-- <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')" /> -->
+    <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')" />
+    <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')" />
+    <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')" />
   </ItemGroup>
 
-  <!-- <ItemGroup>
-    <None Include="../runtimes/win-x64/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-x64/native/" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi.dll')" />
-    <None Include="../runtimes/win-arm64/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-arm64/native/" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi.dll')" />
-    <None Include="../runtimes/win-x86/native/yggdrasilffi.dll" Pack="true" PackagePath="runtimes/win-x86/native/" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi.dll')" />
-    <None Include="../runtimes/linux-x64/native/libyggdrasilffi.so" Pack="true" PackagePath="runtimes/linux-x64/native/" Condition="Exists('../runtimes/linux-x64/native/libyggdrasilffi.so')" />
-    <None Include="../runtimes/linux-arm64/native/libyggdrasilffi.so" Pack="true" PackagePath="runtimes/linux-arm64/native/" Condition="Exists('../runtimes/linux-arm64/native/libyggdrasilffi.so')" />
-    <None Include="../runtimes/linux-musl-x64/native/libyggdrasilffi.so" Pack="true" PackagePath="runtimes/linux-musl-x64/native/" Condition="Exists('../runtimes/linux-musl-x64/native/libyggdrasilffi.so')" />
-    <None Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi.so" Pack="true" PackagePath="runtimes/linux-musl-arm64/native/" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi.so')" />
-    <None Include="../runtimes/osx-x64/native/libyggdrasilffi.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi.dylib')" />
-    <None Include="../runtimes/osx-arm64/native/libyggdrasilffi.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi.dylib')" />
-  </ItemGroup> -->
+  <ItemGroup>
+    <EmbeddedResource Include="../runtimes/win-x64/native/yggdrasilffi_x86_64.dll" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi_x86_64.dll')" />
+    <EmbeddedResource Include="../runtimes/win-arm64/native/yggdrasilffi_arm64.dll" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi_arm64.dll')" />
+    <EmbeddedResource Include="../runtimes/win-x86/native/yggdrasilffi_i686.dll" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi_i686.dll')" />
+    <EmbeddedResource Include="../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so" Condition="Exists('../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so')" />
+    <EmbeddedResource Include="../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so" Condition="Exists('../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so')" />
+    <EmbeddedResource Include="../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl" Condition="Exists('../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl')" />
+    <EmbeddedResource Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl')" />
+    <EmbeddedResource Include="../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib')" />
+    <EmbeddedResource Include="../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib')" />
+  </ItemGroup>
 </Project>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.5-beta.0</Version>
+    <Version>1.0.5-beta.1</Version>
     <YggdrasilCoreVersion>0.17.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.4</Version>
-    <YggdrasilCoreVersion>0.14.2</YggdrasilCoreVersion>
+    <Version>1.0.5-beta.0</Version>
+    <YggdrasilCoreVersion>0.17.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>
     <IncludeSymbols>True</IncludeSymbols>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.5-beta.1</Version>
+    <Version>1.0.5</Version>
     <YggdrasilCoreVersion>0.17.0</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '1.0.2'
+  s.version = '1.0.3'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency "ffi", "~> 1.16.3"
   s.platform = target_platform.call
-  s.metadata["yggdrasil_core_version"] = '0.16.0'
+  s.metadata["yggdrasil_core_version"] = '0.17.0'
 end


### PR DESCRIPTION
Add support for .NET framework.

We do this by stealing some ideas from the Java Engine - instead of using .NET core specific tools to copy the binary during the build and then load it by default we now instead dump it to the temp directory and then manually load it