### PR TITLE
fix: metric bucket start time should be reset everytime it is sent

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -356,7 +356,7 @@ impl EngineState {
             .collect();
 
         if !metrics.is_empty() {
-            let start: DateTime<Utc> = self.toggle_metrics_start;
+            let start = self.toggle_metrics_start;
             self.toggle_metrics_start = Utc::now();
             Some(MetricBucket {
                 toggles: metrics,
@@ -1085,6 +1085,27 @@ mod test {
 
         let metrics = state.get_metrics();
         assert!(metrics.is_none());
+    }
+
+    #[test]
+    pub fn getting_metrics_restarts_time() {
+        let compiled_state = HashMap::new();
+        let mut state = EngineState {
+            compiled_state: Some(compiled_state),
+            ..Default::default()
+        };
+
+        state.count_toggle("some-test-toggle", true);
+
+        let metrics = state.get_metrics().unwrap();
+        let start = metrics.start;
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        state.count_toggle("some-test-toggle", true);
+        let metrics = state.get_metrics().unwrap();
+        let new_start = metrics.start;
+
+        assert!(new_start > start);
     }
 
     #[test]

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -225,6 +225,7 @@ pub struct EngineState {
     compiled_state: Option<CompiledState>,
     previous_state: ClientFeatures,
     toggle_metrics: DashMap<String, Metric>,
+    toggle_metrics_start: DateTime<Utc>,
     pub started: DateTime<Utc>,
 }
 
@@ -233,6 +234,7 @@ impl Default for EngineState {
         Self {
             compiled_state: Default::default(),
             toggle_metrics: Default::default(),
+            toggle_metrics_start: Utc::now(),
             previous_state: Default::default(),
             started: Utc::now(),
         }
@@ -354,9 +356,11 @@ impl EngineState {
             .collect();
 
         if !metrics.is_empty() {
+            let start: DateTime<Utc> = self.toggle_metrics_start;
+            self.toggle_metrics_start = Utc::now();
             Some(MetricBucket {
                 toggles: metrics,
-                start: self.started,
+                start,
                 stop: Utc::now(),
             })
         } else {


### PR DESCRIPTION
A potential fix for the "start" property of the metrics bucket not being reset correctly. 

1. This change lacks tests, HELP WANTED! 
2. What is the SDK supposed to do if it is unable to send the metrics right now? (Might be solved outside of this fix)