### PR TITLE
chore: publish WASM web package

### DIFF
--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish WASM
+name: Build WASM
 
 on:
   push:
@@ -21,7 +21,7 @@ on:
         required: true
 
 jobs:
-  build-and-publish-wasm:
+  build-wasm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-wasm.yaml
+++ b/.github/workflows/build-wasm.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Build WASM
         run: |
           cd yggdrasilwasm
-          wasm-pack build --target nodejs
+          wasm-pack build --target web
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish-wasm.yaml
+++ b/.github/workflows/publish-wasm.yaml
@@ -1,0 +1,48 @@
+name: Publish WASM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New version semver
+        required: true
+        type: string
+      tag:
+        description: NPM tag
+        required: false
+        type: string
+        default: 'latest'
+
+jobs:
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.3.0
+
+      - name: Build WASM
+        run: |
+          cd yggdrasilwasm
+          wasm-pack build --target web --scope unleash
+
+  publish-wasm:
+    needs: [build-wasm]
+    uses: Unleash/.github/.github/workflows/npm-release.yml@v2.0.0
+    with:
+      version: ${{ github.event.inputs.version }}
+      tag: ${{ github.event.inputs.tag }}
+      working-directory: yggdrasilwasm/pkg
+      setup-command: "echo 'Skipping setup. Already done.'"
+    secrets:
+      NPM_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
+      UNLEASH_BOT_APP_ID: ${{ secrets.UNLEASH_BOT_APP_ID }}
+      UNLEASH_BOT_PRIVATE_KEY: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}

--- a/yggdrasilwasm/Cargo.toml
+++ b/yggdrasilwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yggdrasil-wasm"
-version = "0.3.0"
+version = "0.3.1-beta.0"
 authors = ["sighphyre <simon@getunleash.io>"]
 repository = "https://github.com/unleash/yggdrasil"
 description = "Direct WASM bindings to the Yggdrasil engine"

--- a/yggdrasilwasm/Cargo.toml
+++ b/yggdrasilwasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yggdrasil-engine"
+name = "yggdrasil-wasm"
 version = "0.3.0"
 authors = ["sighphyre <simon@getunleash.io>"]
 repository = "https://github.com/unleash/yggdrasil"

--- a/yggdrasilwasm/README.md
+++ b/yggdrasilwasm/README.md
@@ -13,13 +13,13 @@ Please note that this is an experimental project and the API is subject to chang
 First, install the package:
 
 ```sh
-$ yarn add @unleash/yggdrasil-engine
+$ yarn add @unleash/yggdrasil-wasm
 ```
 
 Then, you can use it in your code:
 
 ```ts
-import yggdrasil from '../pkg/yggdrasil_engine'
+import yggdrasil from '@unleash/yggdrasil-wasm'
 
 const context = {
   userId: '7'
@@ -69,7 +69,7 @@ project, run:
 $ wasm-pack build --target web
 ```
 
-There's also a set of integration tests in the `e2e-tests` directory, which will ensure that the WASM module can be loaded and used in Node JS and that calls to the engine are correctly managed. These must be run within the e2e-tests directory:
+There's also a set of [Bun](https://bun.sh/) integration tests in the `e2e-tests` directory, which will ensure that the WASM module can be loaded and that calls to the engine are correctly managed. These must be run within the e2e-tests directory:
 
 ```sh
 $ cd e2e-tests

--- a/yggdrasilwasm/README.md
+++ b/yggdrasilwasm/README.md
@@ -66,7 +66,7 @@ This project uses wasm-bindgen to generate the Rust/JS bindings. To build the
 project, run:
 
 ```sh
-$ wasm-pack build --target nodejs
+$ wasm-pack build --target web
 ```
 
 There's also a set of integration tests in the `e2e-tests` directory, which will ensure that the WASM module can be loaded and used in Node JS and that calls to the engine are correctly managed. These must be run within the e2e-tests directory:

--- a/yggdrasilwasm/e2e-tests/index.test.ts
+++ b/yggdrasilwasm/e2e-tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, test, expect } from 'bun:test'
-import init, { Engine } from '../pkg/yggdrasil_engine'
+import init, { Engine } from '../pkg/yggdrasil_wasm'
 
 type BaseTest = {
   toggleName: string

--- a/yggdrasilwasm/e2e-tests/index.test.ts
+++ b/yggdrasilwasm/e2e-tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, test, expect } from 'bun:test'
-import { Engine } from '../pkg/yggdrasil_engine'
+import init, { Engine } from '../pkg/yggdrasil_engine'
 
 type BaseTest = {
   toggleName: string
@@ -16,16 +16,16 @@ type VariantTest = BaseTest & {
 }
 
 type VariantResponse = {
-  featureEnabled: boolean,
-  payload: Record<string, string>,
-  enabled: boolean,
+  featureEnabled: boolean
+  payload: Record<string, string>
+  enabled: boolean
   name: string
 }
 
 type LegacyVariantResponse = {
-  feature_enabled: boolean,
-  payload: Record<string, string>,
-  enabled: boolean,
+  feature_enabled: boolean
+  payload: Record<string, string>
+  enabled: boolean
   name: string
 }
 
@@ -56,6 +56,8 @@ const extractResult = <T>(response: Response): T => {
   expect(response.status_code).toBe('Ok')
   return response.value as T
 }
+
+await init()
 
 describe('Client Spec Tests', () => {
   test('Client Spec', async () => {
@@ -98,8 +100,8 @@ describe('Client Spec Tests', () => {
 
         for (const variantTest of variantTests) {
           const toggleName = variantTest.toggleName
-          const expectedResult = variantTest.expectedResult as any as LegacyVariantResponse;
-
+          const expectedResult =
+            variantTest.expectedResult as any as LegacyVariantResponse
 
           test(`Variant Test: ${variantTest.description}`, () => {
             const variantResponse = engine.checkVariant(
@@ -121,10 +123,10 @@ describe('Client Spec Tests', () => {
               extractResult<VariantResponse>(variantResponse) ??
               getDisabledVariant(featureEnabled)
 
-            expect(result.name).toBe(expectedResult.name);
-            expect(result.enabled).toBe(expectedResult.enabled);
-            expect(result.featureEnabled).toBe(expectedResult.feature_enabled);
-            expect(result.payload).toEqual(expectedResult.payload);
+            expect(result.name).toBe(expectedResult.name)
+            expect(result.enabled).toBe(expectedResult.enabled)
+            expect(result.featureEnabled).toBe(expectedResult.feature_enabled)
+            expect(result.payload).toEqual(expectedResult.payload)
           })
         }
       })


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3335/create-a-publish-workflow-for-our-wasm-package

Adds the publish WASM workflow and cleans up a few things.

I wonder if we can get away with reusing our npm-release workflow. Is there a better way to test this than to just merge it and trying to publish a release?