### PR TITLE
chore: fix publish javascript workflow

### DIFF
--- a/.github/workflows/publish-javascript.yml
+++ b/.github/workflows/publish-javascript.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Build
         run: |
           cd javascript-engine
+          bun i
           bun run build
 
       - name: 🔖 Create version

--- a/.github/workflows/publish-javascript.yml
+++ b/.github/workflows/publish-javascript.yml
@@ -47,15 +47,15 @@ jobs:
           PACKAGE_VERSION=$(bun -p "'${{ inputs.version }}'.replace(/^v/, '')")
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
 
+      - name: 🔖 Create version
+        run: yarn version --new-version ${PACKAGE_VERSION} --no-commit-hooks
+        working-directory: javascript-engine
+
       - name: Build
         run: |
           cd javascript-engine
           bun i
           bun run build
-
-      - name: 🔖 Create version
-        run: yarn version --new-version ${PACKAGE_VERSION} --no-commit-hooks
-        working-directory: javascript-engine
 
       - name: 🚢 Push to git
         run: |

--- a/.github/workflows/publish-javascript.yml
+++ b/.github/workflows/publish-javascript.yml
@@ -33,6 +33,12 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
@@ -57,7 +63,7 @@ jobs:
           git push --tags
 
       - name: 📦️ Publish to NPM
-        run: bun publish --access public --tag ${{ inputs.tag }}
+        run: npm publish --access public --tag ${{ inputs.tag }}
         working-directory: javascript-engine
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/javascript-engine/bun.lock
+++ b/javascript-engine/bun.lock
@@ -3,11 +3,9 @@
   "workspaces": {
     "": {
       "name": "javascript-engine",
-      "dependencies": {
-        "@unleash/yggdrasil-wasm": "^0.3.1-beta.1",
-      },
       "devDependencies": {
         "@types/bun": "latest",
+        "@unleash/yggdrasil-wasm": "^0.3.1-beta.1",
         "typescript": "^5",
       },
     },

--- a/javascript-engine/package.json
+++ b/javascript-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/yggdrasil-engine",
-  "version": "0.0.1",
+  "version": "0.0.1-beta.0",
   "description": "Unleash Yggdrasil Engine for JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/javascript-engine/package.json
+++ b/javascript-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/yggdrasil-engine",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "description": "Unleash Yggdrasil Engine for JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/javascript-engine/package.json
+++ b/javascript-engine/package.json
@@ -14,5 +14,8 @@
   },
   "dependencies": {
     "@unleash/yggdrasil-wasm": "^0.3.1-beta.1"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/javascript-engine/package.json
+++ b/javascript-engine/package.json
@@ -6,14 +6,13 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist && bun tsc --emitDeclarationOnly"
+    "build": "bun build ./src/index.ts --outdir ./dist && bun tsc --emitDeclarationOnly && bun run build:copy:wasm",
+    "build:copy:wasm": "cp ./node_modules/@unleash/yggdrasil-wasm/*.js ./node_modules/@unleash/yggdrasil-wasm/*.d.ts ./node_modules/@unleash/yggdrasil-wasm/*.wasm ./dist/"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@unleash/yggdrasil-wasm": "^0.3.1-beta.1",
     "typescript": "^5"
-  },
-  "dependencies": {
-    "@unleash/yggdrasil-wasm": "^0.3.1-beta.1"
   },
   "files": [
     "dist"

--- a/javascript-engine/package.json
+++ b/javascript-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/yggdrasil-engine",
-  "version": "0.0.1-beta.0",
+  "version": "0.0.1-beta.1",
   "description": "Unleash Yggdrasil Engine for JavaScript.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
https://linear.app/unleash/issue/2-3336/create-a-publish-workflow-for-our-javascript-engine

This should just work, except I forgot to install dependencies before building and a few other details 🫠 

This is now correctly publishing: https://www.npmjs.com/package/@unleash/yggdrasil-engine
Workflow runs: https://github.com/Unleash/yggdrasil/actions/workflows/publish-javascript.yml