### PR TITLE
feat(java): expose enabled on list features in core and java

### DIFF
--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
-yggdrasilCoreVersion=0.17.2
-version=0.1.0
+yggdrasilCoreVersion=0.17.3
+version=0.1.1

--- a/java-engine/src/main/java/io/getunleash/engine/FeatureDef.java
+++ b/java-engine/src/main/java/io/getunleash/engine/FeatureDef.java
@@ -9,15 +9,18 @@ public class FeatureDef {
     private final String name;
     private final Optional<String> type;
     private final String project;
+    private final boolean enabled;
 
     @JsonCreator
     FeatureDef(
             @JsonProperty("name") String name,
             @JsonProperty("type") String featureType,
-            @JsonProperty("project") String project) {
+            @JsonProperty("project") String project,
+            @JsonProperty("enabled") boolean enabled) {
         this.name = name;
         this.project = project;
         this.type = Optional.ofNullable(featureType);
+        this.enabled = enabled;
     }
 
     public String getName() {
@@ -30,5 +33,9 @@ public class FeatureDef {
 
     public String getProject() {
         return project;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -112,6 +112,7 @@ class UnleashEngineTest {
         assertEquals("Feature.A", featureA.get().getName());
         assertEquals("test", featureA.get().getProject());
         assertTrue(featureA.get().getType().isPresent());
+        assertTrue(featureA.get().isEnabled());
         assertEquals("experiment", featureA.get().getType().get());
     }
 
@@ -260,6 +261,7 @@ class UnleashEngineTest {
         assertEquals(expectedIsEnabled, result);
     }
 
+    @SuppressWarnings("unused")
     @Test
     void testResourceCleanup() throws InterruptedException {
         UnleashFFI ffiMock = Mockito.mock(UnleashFFI.class);
@@ -289,7 +291,8 @@ class UnleashEngineTest {
     void testCoreVersionIsRetrieved() {
         String coreVersion = UnleashEngine.getCoreVersion();
         assertNotNull(coreVersion);
-        // check that it contains two dots, close enough for a quick and dirty but stable semver check
+        // check that it contains two dots, close enough for a quick and dirty but
+        // stable semver check
         assertTrue(coreVersion.split("\\.").length >= 3);
     }
 

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -63,6 +63,7 @@ pub struct ToggleDefinition {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub feature_type: Option<String>,
     pub project: String,
+    pub enabled: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -479,6 +480,7 @@ impl EngineState {
                             feature_type: toggle.feature_type.clone(),
                             name: toggle.name.clone(),
                             project: toggle.project.clone(),
+                            enabled: toggle.enabled,
                         }
                     })
                     .collect::<Vec<ToggleDefinition>>()


### PR DESCRIPTION
Exposes the environment `enabled` property for a toggle on list features. Folks on the Java SDK are asking for it back