### PR TITLE
Java: Custom strategies resolved in getVariant

### DIFF
--- a/java-engine/build.gradle.kts
+++ b/java-engine/build.gradle.kts
@@ -62,7 +62,7 @@ val copyTestBinary = tasks.register<Copy>("copyTestBinary") {
     val targetPath = file("build/resources/test/native")
 
     val binaryName = when {
-        os.contains("mac") && platform.contains("arm") -> "libyggdrasilffi_arm64.dylib"
+        os.contains("mac") && (platform.contains("arm") || platform.contains("aarch64")) -> "libyggdrasilffi_arm64.dylib"
         os.contains("mac") -> "libyggdrasilffi_x86_64.dylib"
         os.contains("win") -> "yggdrasilffi_x86_64.dll"
         os.contains("linux") -> "libyggdrasilffi_x86_64.so"
@@ -80,6 +80,7 @@ val copyTestBinary = tasks.register<Copy>("copyTestBinary") {
 tasks.named<Test>("test") {
     dependsOn(copyTestBinary)
     useJUnitPlatform()
+    testLogging { exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL }
 }
 
 publishing {

--- a/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
+++ b/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UnleashEngine {
-    private static final String EMPTY_STRATEGY_RESULTS = "{}";
     private static final Logger log = LoggerFactory.getLogger(UnleashEngine.class);
     private final UnleashFFI yggdrasil;
     private final Pointer enginePtr;
@@ -97,10 +96,11 @@ public class UnleashEngine {
             throws YggdrasilInvalidInputException, YggdrasilError {
         try {
             String jsonContext = mapper.writeValueAsString(context);
+            String strategyResults = customStrategiesEvaluator.eval(name, context);
             VariantDef response = read(
                     yggdrasil.checkVariant(this.enginePtr, toUtf8Pointer(name),
                             toUtf8Pointer(jsonContext),
-                            toUtf8Pointer(EMPTY_STRATEGY_RESULTS)),
+                            toUtf8Pointer(strategyResults)),
                     new TypeReference<YggResponse<VariantDef>>() {
                     });
             return response;

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -58,7 +58,8 @@ class UnleashEngineTest {
 
     @BeforeEach
     void createEngine() {
-        engine = new UnleashEngine();
+        List<IStrategy> customStrategies = List.of(alwaysTrue("custom"));
+        engine = new UnleashEngine(customStrategies);
     }
 
     @Test
@@ -97,6 +98,17 @@ class UnleashEngineTest {
         }
 
         assertEquals("disabled", variant.getName());
+        assertFalse(variant.isEnabled());
+    }
+
+    @Test
+    void testGetVariantWithCustomStrategy() throws Exception {
+        engine.takeState(simpleFeatures);
+
+        Context context = new Context();
+        VariantDef variant = engine.getVariant("Feature.D", context);
+
+        assertEquals(variant.isFeatureEnabled(), true);
         assertFalse(variant.isEnabled());
     }
 

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -103,7 +103,7 @@ class UnleashEngineTest {
 
     @Test
     void testGetVariantWithCustomStrategy() throws Exception {
-        engine.takeState(simpleFeatures);
+        engine.takeState("{\"version\":1,\"features\":[{\"name\":\"Feature.D\",\"description\":\"Has a custom strategy\",\"enabled\":true,\"strategies\":[{\"name\":\"custom\",\"constraints\":[],\"parameters\":{\"foo\":\"bar\"}}]}]}");
 
         Context context = new Context();
         VariantDef variant = engine.getVariant("Feature.D", context);


### PR DESCRIPTION
## About the changes

Hello!

My main use case for using Unleash with the Java Client is `evaluateAllToggles()`. After migrating to the 10.x version, I was puzzled about why some of my tests kept failing. After some digging, I think I've pinpointed the issue: custom strategies aren't resolved on `getVariant()` calls, which is what `evaluateAllToggles()` uses underneath. This PR contains a fix + a test case that covers this. 

Also added a build fix for ARM-based Macs as I've had some issues running the test suite initially ("aarch64" vs "arm64" returned as architecture leading to incorrectly named native package file).

## Discussion points

I've had a brief look at other client implementations in the repo (Ruby, C# etc.) and I _think_ the intention is to resolve custom strategies on `getVariant` as well, but that is only my assumption - please feel free to correct me. I assume the `EMPTY_STRATEGY_RESULTS` is an unintentional leftover from an earlier stage of development. Having the custom strategies resolved is also the behaviour present in the 9.x branch of the Unleash Java Client.
