### PR TITLE
release(java): 0.1.2

### DIFF
--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.17.3
-version=0.1.1
+version=0.1.2


### PR DESCRIPTION
Contains a patch for the Java engine that allows custom strategies to work on getVariant and some extended support for loading mac binaries. Courtesy of community patch #231 