### PR TITLE
chore: fix wasm-related java-engine build failure

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -34,8 +34,6 @@ jobs:
           rustup show
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Build yggdrasil
-        run: cargo build --release
       - name: Build yggdrasil wasm
         working-directory: pure-wasm
         run: cargo build --release --target wasm32-unknown-unknown

--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -36,6 +36,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Build yggdrasil
         run: cargo build --release
+      - name: Build yggdrasil wasm
+        working-directory: pure-wasm
+        run: cargo build --release --target wasm32-unknown-unknown
       ## end build yggdrasil
 
       ## Test requirements


### PR DESCRIPTION
Attempts to fix the java-engine build errors related to pure-was not being compiled yet