### PR TITLE
fix: allow runtime hostname to be specified in context

### DIFF
--- a/pure-wasm/src/lib.rs
+++ b/pure-wasm/src/lib.rs
@@ -6,16 +6,18 @@ use std::{
     mem, slice,
 };
 
+#[allow(clippy::all)]
 mod messaging {
     #![allow(dead_code)]
     #![allow(non_snake_case)]
+    #![allow(warnings)]
     include!("enabled-message_generated.rs");
 }
 
 use flatbuffers::FlatBufferBuilder;
 use messaging::messaging::ResponseBuilder;
 
-use unleash_yggdrasil::{Context as YggContext, EngineState};
+use unleash_yggdrasil::{Context as YggContext, EngineState, state::EnrichedContext};
 
 use getrandom::register_custom_getrandom;
 
@@ -157,7 +159,8 @@ pub extern "C" fn check_enabled(engine_ptr: i32, message_ptr: i32, message_len: 
         };
 
         let engine = &mut *(engine_ptr as *mut EngineState);
-        let enabled = engine.check_enabled(toggle_name, &context, &None);
+        let enriched_context = EnrichedContext::from(context, toggle_name.to_string(), None);
+        let enabled = engine.check_enabled(&enriched_context);
         engine.count_toggle(toggle_name, enabled.unwrap_or(false));
 
         let response = build_response(enabled, None);

--- a/unleash-yggdrasil/src/state.rs
+++ b/unleash-yggdrasil/src/state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use unleash_types::client_features::Context;
 
+#[derive(Clone)]
 pub struct EnrichedContext {
     pub user_id: Option<String>,
     pub session_id: Option<String>,
@@ -11,6 +12,7 @@ pub struct EnrichedContext {
     pub properties: Option<HashMap<String, String>>,
     pub external_results: Option<HashMap<String, bool>>,
     pub(crate) toggle_name: String,
+    pub(crate) runtime_hostname: Option<String>,
 }
 
 impl EnrichedContext {
@@ -29,6 +31,7 @@ impl EnrichedContext {
             properties: context.properties,
             external_results,
             toggle_name,
+            runtime_hostname: None,
         }
     }
 }

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -130,6 +130,14 @@ fn context_value(node: Pairs<Rule>) -> ContextResolver {
         Rule::environment => Box::new(|context: &Context| context.environment.clone()),
         Rule::session_id => Box::new(|context: &Context| context.session_id.clone()),
         Rule::remote_address => Box::new(|context: &Context| context.remote_address.clone()),
+        #[cfg(feature = "wall-clock")]
+        Rule::current_time => Box::new(|context: &Context| {
+            context
+                .current_time
+                .clone()
+                .or_else(|| Some(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()))
+        }),
+        #[cfg(not(feature = "wall-clock"))]
         Rule::current_time => Box::new(|context: &Context| context.current_time.clone()),
         Rule::random => {
             let value = child
@@ -402,7 +410,7 @@ fn rollout_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {
 }
 
 #[cfg(feature = "hostname")]
-fn get_hostname() -> CompileResult<String> {
+fn get_hostname(_: &Context) -> CompileResult<String> {
     //This is primarily for testing purposes
     if let Ok(hostname_env) = env::var("hostname") {
         return Ok(hostname_env);
@@ -418,7 +426,10 @@ fn get_hostname() -> CompileResult<String> {
 }
 
 #[cfg(not(feature = "hostname"))]
-fn get_hostname() -> CompileResult<String> {
+fn get_hostname(context: &Context) -> CompileResult<String> {
+    if let Some(hostname) = &context.runtime_hostname {
+        return Ok(hostname.clone());
+    }
     Err(SdkError::StrategyParseError(
         "Hostname is not supported on this platform".into(),
     ))
@@ -432,9 +443,11 @@ fn hostname_constraint(node: Pairs<Rule>) -> CompileResult<RuleFragment> {
         .map(|x| x.to_lowercase())
         .collect();
 
-    Ok(Box::new(move |_: &Context| match get_hostname() {
-        Ok(hostname) => target_hostnames.contains(&hostname.to_lowercase()),
-        Err(_) => false,
+    Ok(Box::new(move |context: &Context| {
+        match get_hostname(context) {
+            Ok(hostname) => target_hostnames.contains(&hostname.to_lowercase()),
+            Err(_) => false,
+        }
     }))
 }
 
@@ -664,6 +677,7 @@ mod tests {
             remote_address: None,
             toggle_name: "".into(),
             external_results: None,
+            runtime_hostname: None,
         }
     }
 
@@ -683,6 +697,7 @@ mod tests {
                 properties: Default::default(),
                 toggle_name: Default::default(),
                 external_results: None,
+                runtime_hostname: None,
             }
         }
     }
@@ -822,6 +837,7 @@ mod tests {
             remote_address: None,
             toggle_name: "".into(),
             external_results: None,
+            runtime_hostname: None,
         };
 
         let rule = compile_rule(rule).expect("");


### PR DESCRIPTION
This reworks some of the public APIs to take the EnrichedContext directly during flag evaluation. We do this so that we can sneak in a new parameter - runtime_hostname on the enriched context. That in turn we use for the hostname strategy in cases where we don't have access to IO - e.g. WASM.