### PR TITLE
chore: fix wrong usings of epoch millis/nanos

### DIFF
--- a/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
+++ b/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
@@ -193,7 +193,7 @@ public class UnleashEngine {
 
   public MetricsBucket getMetrics() throws JsonMappingException, JsonProcessingException {
     ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-    long packed = (long) getMetrics.apply(this.enginePointer, now.toEpochSecond())[0];
+    long packed = (long) getMetrics.apply(this.enginePointer, now.toInstant().toEpochMilli())[0];
     int ptr = (int) (packed & 0xFFFFFFFFL);
     int len = (int) (packed >>> 32);
     byte[] bytes = instance.memory().readBytes(ptr, len);

--- a/java-engine/src/test/java/io/getunleash/engine/LibraryTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/LibraryTest.java
@@ -3,9 +3,14 @@
  */
 package io.getunleash.engine;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import messaging.MetricsBucket;
 import messaging.ToggleEntry;
 import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
 
 public class LibraryTest {
   @Test
@@ -49,6 +54,30 @@ public class LibraryTest {
         bucket.toggles(0).key().equals("Feature.C") ? bucket.toggles(0) : bucket.toggles(1);
     assert (featA.value().yes() == 1);
     assert (featC.value().yes() == 2);
+  }
+
+  @Test
+  public void metricsBucketStartStopAreCorrect() throws Exception {
+    var engine = new UnleashEngine();
+    String path = "../test-data/simple.json";
+    String json = new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(path)));
+    engine.takeState(json);
+    boolean result = engine.isEnabled("Feature.A", new Context());
+    MetricsBucket bucket = engine.getMetrics();
+
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+    Instant start = Instant.ofEpochMilli(bucket.start());
+    ZonedDateTime utcStart = start.atZone(ZoneOffset.UTC);
+
+    Instant stop = Instant.ofEpochMilli(bucket.stop());
+    ZonedDateTime utcStop = stop.atZone(ZoneOffset.UTC);
+
+    // Currently doesn't work because the start time is hardcoded to a date/time in 2022 in pure-wasm lib.rs
+    //assert(utcStart.isBefore(now)) : "start not before now. start: " + utcStart + " - stop: " + utcStop;
+    //assert(utcStart.plusMinutes(1).isAfter(now)) : "start plus minute not after now. start: " + utcStart + " - stop: " + utcStop;
+    assert(utcStop.isBefore(now)) : "stop not before now";
+    assert(utcStop.plusMinutes(1).isAfter(now)) : "stop plus minute not after now" + utcStop;
   }
 
   @Test

--- a/java-engine/src/test/java/io/getunleash/engine/LibraryTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/LibraryTest.java
@@ -10,8 +10,6 @@ import messaging.MetricsBucket;
 import messaging.ToggleEntry;
 import org.junit.jupiter.api.Test;
 
-import java.time.ZonedDateTime;
-
 public class LibraryTest {
   @Test
   public void engineCanBeNewedUpWithoutError() throws Exception {
@@ -73,11 +71,14 @@ public class LibraryTest {
     Instant stop = Instant.ofEpochMilli(bucket.stop());
     ZonedDateTime utcStop = stop.atZone(ZoneOffset.UTC);
 
-    // Currently doesn't work because the start time is hardcoded to a date/time in 2022 in pure-wasm lib.rs
-    //assert(utcStart.isBefore(now)) : "start not before now. start: " + utcStart + " - stop: " + utcStop;
-    //assert(utcStart.plusMinutes(1).isAfter(now)) : "start plus minute not after now. start: " + utcStart + " - stop: " + utcStop;
-    assert(utcStop.isBefore(now)) : "stop not before now";
-    assert(utcStop.plusMinutes(1).isAfter(now)) : "stop plus minute not after now" + utcStop;
+    // Currently doesn't work because the start time is hardcoded to a date/time in 2022 in
+    // pure-wasm lib.rs
+    // assert(utcStart.isBefore(now)) : "start not before now. start: " + utcStart + " - stop: " +
+    // utcStop;
+    // assert(utcStart.plusMinutes(1).isAfter(now)) : "start plus minute not after now. start: " +
+    // utcStart + " - stop: " + utcStop;
+    assert (utcStop.isBefore(now)) : "stop not before now";
+    assert (utcStop.plusMinutes(1).isAfter(now)) : "stop plus minute not after now" + utcStop;
   }
 
   @Test

--- a/pure-wasm/src/lib.rs
+++ b/pure-wasm/src/lib.rs
@@ -177,8 +177,8 @@ pub fn build_metrics_response(
                 .collect();
             let toggle_vector = builder.create_vector(&items);
             let mut resp_builder = MetricsBucketBuilder::new(&mut builder);
-            resp_builder.add_start(metrics.start.timestamp_nanos_opt().unwrap());
-            resp_builder.add_stop(metrics.stop.timestamp_nanos_opt().unwrap());
+            resp_builder.add_start(metrics.start.timestamp_millis());
+            resp_builder.add_stop(metrics.stop.timestamp_millis());
             resp_builder.add_toggles(toggle_vector);
             resp_builder.finish()
         } else {
@@ -236,7 +236,7 @@ pub extern "C" fn check_enabled(engine_ptr: i32, message_ptr: i32, message_len: 
 pub extern "C" fn get_metrics(engine_ptr: i32, close_time: i64) -> u64 {
     unsafe {
         let engine = &mut *(engine_ptr as *mut EngineState);
-        let metrics = engine.get_metrics(DateTime::from_timestamp_nanos(close_time));
+        let metrics = engine.get_metrics(DateTime::from_timestamp_millis(close_time).unwrap());
         let response = build_metrics_response(metrics);
 
         let ptr: u32 = response.as_ptr() as u32;


### PR DESCRIPTION
Fixes the issue of passing seconds to rust which then assumes it's nanos, sends nanos back, which we then parse in as milliseconds... now it's milliseconds all the way!