### PR TITLE
fix(ruby): memory leak in metrics

### DIFF
--- a/ruby-engine/lib/yggdrasil_engine.rb
+++ b/ruby-engine/lib/yggdrasil_engine.rb
@@ -63,8 +63,8 @@ class YggdrasilEngine
   attach_function :get_metrics, [:pointer], :pointer
   attach_function :free_response, [:pointer], :void
 
-  attach_function :count_toggle, %i[pointer string bool], :void
-  attach_function :count_variant, %i[pointer string string], :void
+  attach_function :count_toggle, %i[pointer string bool], :pointer
+  attach_function :count_variant, %i[pointer string string], :pointer
 
   attach_function :list_known_toggles, [:pointer], :pointer
 

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '1.0.3'
+  s.version = '1.0.4'
   s.date = '2023-06-28'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'


### PR DESCRIPTION
Fixes a leak in the metrics handling for the Ruby engine. This was caused by the incorrect return type on the FFI function on the Ruby side.