### PR TITLE
chore: test python build

### DIFF
--- a/python-engine/pyproject.toml
+++ b/python-engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yggdrasil-engine"
-version = "0.1.5"
+version = "0.1.6-beta.0"
 description = "Engine for evaluating Unleash feature flags"
 authors = ["Simon Hornby <liquidwicked64@gmail.com>"]
 license = "MIT"

--- a/python-engine/pyproject.toml
+++ b/python-engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yggdrasil-engine"
-version = "0.1.6-beta.0"
+version = "0.1.6-beta.1"
 description = "Engine for evaluating Unleash feature flags"
 authors = ["Simon Hornby <liquidwicked64@gmail.com>"]
 license = "MIT"

--- a/python-engine/tox.ini
+++ b/python-engine/tox.ini
@@ -5,8 +5,7 @@ envlist =
 skipsdist = true
 
 [testenv]
-deps = poetry
-skip_install = true
+deps = poetry==1.8.2
 allowlist_externals = rm, python, cp, mkdir
 
 setenv =
@@ -43,6 +42,9 @@ setenv =
     musllinux_arm64: OUTPUT_BINARY = libyggdrasilffi.so
 
 commands =
+    python -V
+    poetry --version
+
     rm -rf dist yggdrasil_engine/lib
     mkdir -p staging yggdrasil_engine/lib
 


### PR DESCRIPTION
Poetry got updated to 2.x. That version doesn't package native library correctly with out build scripts, which leads to a package that crashes on startup. This pins the Poetry version in the build to a working version