### PR TITLE
fix(java): don't warn when using a custom strategy on built in strategies

### DIFF
--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,3 +1,3 @@
 group=io.getunleash
 yggdrasilCoreVersion=0.17.3
-version=0.2.0
+version=0.2.1

--- a/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
+++ b/java-engine/src/main/java/io/getunleash/engine/UnleashEngine.java
@@ -49,7 +49,7 @@ public class UnleashEngine {
       IStrategy fallbackStrategy,
       NativeInterface nativeInterface) {
     if (customStrategies != null && !customStrategies.isEmpty()) {
-      List<String> builtInStrategies = new ArrayList<>();
+      List<String> builtInStrategies = getBuiltInStrategies();
       this.customStrategiesEvaluator =
           new CustomStrategiesEvaluator(
               customStrategies.stream(), fallbackStrategy, new HashSet<String>(builtInStrategies));

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -566,7 +566,7 @@ impl EngineState {
             .map(|seed| {
                 normalized_hash(group_id, &seed, total_weight, VARIANT_NORMALIZATION_SEED).unwrap()
             })
-            .unwrap_or_else(|| rand::thread_rng().gen_range(0..total_weight));
+            .unwrap_or_else(|| rand::rng().random_range(0..total_weight));
 
         let mut total_weight = 0;
         for variant in variants {

--- a/unleash-yggdrasil/src/strategy_parsing.rs
+++ b/unleash-yggdrasil/src/strategy_parsing.rs
@@ -149,7 +149,7 @@ fn context_value(node: Pairs<Rule>) -> ContextResolver {
                     )
                 })
                 .unwrap_or(100);
-            Box::new(move |_: &Context| Some(rand::thread_rng().gen_range(1..value).to_string()))
+            Box::new(move |_: &Context| Some(rand::rng().random_range(1..value).to_string()))
         }
         Rule::property => context_property(child.into_inner()),
         _ => unreachable!(),


### PR DESCRIPTION
Built in strategies are now hydrated into the engine so that it doesn't complain when it can't detect "flexibleRollout" as a built in strategy