### PR TITLE
chore(dotnet): add net6 target and deal with nullables

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -98,13 +98,15 @@ internal static class NativeLibLoader
 
     internal static IntPtr LoadFunctionPointer(IntPtr libHandle, string functionName)
     {
-        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
         {
             var getExportMethod = nativeLibraryType.GetMethod("GetExport", new[] { typeof(IntPtr), typeof(string) });
             if (getExportMethod != null)
             {
-                return (IntPtr)getExportMethod.Invoke(null, new object[] { libHandle, functionName });
+                var invocationPtr = (IntPtr?)getExportMethod.Invoke(null, new object[] { libHandle, functionName });
+                if (invocationPtr.HasValue && invocationPtr.Value != IntPtr.Zero)
+                    return invocationPtr.Value;
             }
         }
 
@@ -116,27 +118,31 @@ internal static class NativeLibLoader
 
     private static IntPtr LoadBinary(string libPath)
     {
-        IntPtr handle;
+        IntPtr? handle;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             handle = LoadWindowsLibrary(libPath);
         else
             handle = LoadUnixLibrary(libPath);
 
-        if (handle == IntPtr.Zero)
+        if (handle is null || handle == IntPtr.Zero)
             throw new DllNotFoundException($"Failed to load library from {libPath}");
 
-        return handle;
+        return (IntPtr)handle;
     }
 
     private static IntPtr LoadUnixLibrary(string libPath)
     {
         // Try NativeLibrary.Load (works on .NET Core 3+)
-        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
         {
             var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
             if (loadMethod != null)
-                return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
+            {
+                var invocationPtr = (IntPtr?)loadMethod.Invoke(null, new object[] { libPath });
+                if (invocationPtr.HasValue && invocationPtr.Value != IntPtr.Zero)
+                    return invocationPtr.Value;
+            }
         }
         return dlopen(libPath, RTLD_NOW);
     }
@@ -144,18 +150,21 @@ internal static class NativeLibLoader
     private static IntPtr LoadWindowsLibrary(string libPath)
     {
         // Try NativeLibrary.Load (works on .NET Core 3+)
-        Type nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
+        var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
         {
             var loadMethod = nativeLibraryType.GetMethod("Load", new[] { typeof(string) });
             if (loadMethod != null)
-                return (IntPtr)loadMethod.Invoke(null, new object[] { libPath });
+            {
+                var invocationPtr = (IntPtr?)loadMethod.Invoke(null, new object[] { libPath });
+                if (invocationPtr.HasValue && invocationPtr.Value != IntPtr.Zero)
+                    return invocationPtr.Value;
+            }
         }
 
         return LoadLibrary(libPath);
     }
 
-#if NETSTANDARD
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern IntPtr LoadLibrary(string dllToLoad);
 
@@ -175,5 +184,4 @@ internal static class NativeLibLoader
 
     [DllImport("libdl.so.2", SetLastError = true, CharSet = CharSet.Ansi)]
     private static extern IntPtr dlsym(IntPtr handle, string symbol);
-#endif
 }

--- a/dotnet-engine/Yggdrasil.Engine/Types.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Types.cs
@@ -56,7 +56,7 @@ public class Payload
     public string Type { get; set; }
     public string Value { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj == this) return true;
         if (obj == null) return false;

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -21,7 +21,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This adds .net 6 as a build target and deals with the fallout, to accommodate the feature request in #277 / #278 

A lot of the net6 APIs return nullable results, and some of the APIs still require non-nullable types. So we need to wrap these cases in checks.

There's also a bunch of imported methods hidden behind a NETSTANDARD ifdef, removed that ifdef.
This would need some testing before it's shipped.