### PR TITLE
chore: use a reentrant read write lock for better performance

### DIFF
--- a/java-engine/src/main/java/io/getunleash/engine/WasmInterface.java
+++ b/java-engine/src/main/java/io/getunleash/engine/WasmInterface.java
@@ -153,7 +153,7 @@ public class WasmInterface implements NativeInterface {
   public Variant checkVariant(int enginePtr, byte[] contextBytes) {
     synchronized (engineLock) {
       int contextPtr = (int) alloc.apply(contextBytes.length)[0];
-        instance.memory().write(contextPtr, contextBytes);
+      instance.memory().write(contextPtr, contextBytes);
 
       long response = checkVariant.apply(enginePtr, contextPtr, contextBytes.length)[0];
       Variant variant = derefWasmPointer(response, Variant::getRootAsVariant);


### PR DESCRIPTION
- Multiple readers can read concurrently.
- Only one writer can write.
- When a writer wants the lock, new readers are blocked.
- Existing readers finish, then writer proceeds (no starvation).