### PR TITLE
Java: fix get variant counts

### DIFF
--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -404,9 +404,10 @@ class UnleashEngineTest {
 
   @Test
   void testMetrics() throws YggdrasilError, YggdrasilInvalidInputException {
-    UnleashEngine engine = new UnleashEngine();
-    String features =
-        loadFeaturesFromFile("../client-specification/specifications/08-variants.json");
+    String features = "{\"version\":1,\"features\":[" +
+            "{\"name\":\"Feature.Variants.A\",\"enabled\":true,\"strategies\":[],\"variants\":[{\"name\":\"variant1\",\"weight\":1}]}," +
+            "{\"name\":\"Feature.Variants.B\",\"enabled\":true,\"strategies\":[{\"name\":\"userWithId\",\"parameters\":{\"userIds\":\"123\"}}],\"variants\":[]}" +
+            "]}";
     engine.takeState(features);
 
     engine.getVariant("Feature.Variants.A", new Context());
@@ -432,8 +433,8 @@ class UnleashEngineTest {
     assertEquals(1, bucket.getToggles().get("Feature.Variants.A").getVariants().get("variant1"));
     assertNull(bucket.getToggles().get("Missing.Feature"));
 
-    assertEquals(1, bucket.getToggles().get("Feature.Variants.B").getYes());
-    assertEquals(0, bucket.getToggles().get("Feature.Variants.B").getNo());
+    assertEquals(0, bucket.getToggles().get("Feature.Variants.B").getYes());
+    assertEquals(1, bucket.getToggles().get("Feature.Variants.B").getNo());
 
     assertEquals(0, bucket.getToggles().get("Missing.but.checked").getYes());
     assertEquals(2, bucket.getToggles().get("Missing.but.checked").getNo());

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -209,10 +209,11 @@ class UnleashEngineTest {
 
   @Test
   void testMetrics() throws YggdrasilInvalidInputException {
-    String features = "{\"version\":1,\"features\":[" +
-            "{\"name\":\"Feature.Variants.A\",\"enabled\":true,\"strategies\":[],\"variants\":[{\"name\":\"variant1\",\"weight\":1}]}," +
-            "{\"name\":\"Feature.Variants.B\",\"enabled\":true,\"strategies\":[{\"name\":\"userWithId\",\"parameters\":{\"userIds\":\"123\"}}],\"variants\":[]}" +
-            "]}";
+    String features =
+        "{\"version\":1,\"features\":["
+            + "{\"name\":\"Feature.Variants.A\",\"enabled\":true,\"strategies\":[],\"variants\":[{\"name\":\"variant1\",\"weight\":1}]},"
+            + "{\"name\":\"Feature.Variants.B\",\"enabled\":true,\"strategies\":[{\"name\":\"userWithId\",\"parameters\":{\"userIds\":\"123\"}}],\"variants\":[]}"
+            + "]}";
     engine.takeState(features);
 
     engine.getVariant("Feature.Variants.A", new Context());

--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -41,201 +41,6 @@ class TestSuite {
 
 class UnleashEngineTest {
 
-  String rawState =
-      "{\n"
-          + //
-          "    \"version\": 2,\n"
-          + //
-          "    \"segments\": [\n"
-          + //
-          "        {\n"
-          + //
-          "            \"id\": 1,\n"
-          + //
-          "            \"name\": \"some-name\",\n"
-          + //
-          "            \"description\": null,\n"
-          + //
-          "            \"constraints\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"contextName\": \"some-name\",\n"
-          + //
-          "                    \"operator\": \"IN\",\n"
-          + //
-          "                    \"value\": \"name\",\n"
-          + //
-          "                    \"inverted\": false,\n"
-          + //
-          "                    \"caseInsensitive\": true\n"
-          + //
-          "                }\n"
-          + //
-          "            ]\n"
-          + //
-          "        }\n"
-          + //
-          "    ],\n"
-          + //
-          "    \"features\": [\n"
-          + //
-          "        {\n"
-          + //
-          "            \"name\": \"Test.old\",\n"
-          + //
-          "            \"description\": \"No variants here!\",\n"
-          + //
-          "            \"enabled\": true,\n"
-          + //
-          "            \"strategies\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"default\"\n"
-          + //
-          "                }\n"
-          + //
-          "            ],\n"
-          + //
-          "            \"variants\": null,\n"
-          + //
-          "            \"createdAt\": \"2019-01-24T10:38:10.370Z\"\n"
-          + //
-          "        },\n"
-          + //
-          "        {\n"
-          + //
-          "            \"name\": \"Test.variants\",\n"
-          + //
-          "            \"description\": null,\n"
-          + //
-          "            \"enabled\": true,\n"
-          + //
-          "            \"strategies\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"default\",\n"
-          + //
-          "                    \"segments\": [\n"
-          + //
-          "                        1\n"
-          + //
-          "                    ]\n"
-          + //
-          "                }\n"
-          + //
-          "            ],\n"
-          + //
-          "            \"variants\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"variant1\",\n"
-          + //
-          "                    \"weight\": 50\n"
-          + //
-          "                },\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"variant2\",\n"
-          + //
-          "                    \"weight\": 50\n"
-          + //
-          "                }\n"
-          + //
-          "            ],\n"
-          + //
-          "            \"createdAt\": \"2019-01-24T10:41:45.236Z\"\n"
-          + //
-          "        },\n"
-          + //
-          "        {\n"
-          + //
-          "            \"name\": \"featureX\",\n"
-          + //
-          "            \"enabled\": true,\n"
-          + //
-          "            \"strategies\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"default\"\n"
-          + //
-          "                }\n"
-          + //
-          "            ]\n"
-          + //
-          "        },\n"
-          + //
-          "        {\n"
-          + //
-          "            \"name\": \"featureY\",\n"
-          + //
-          "            \"enabled\": false,\n"
-          + //
-          "            \"strategies\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"baz\",\n"
-          + //
-          "                    \"parameters\": {\n"
-          + //
-          "                        \"foo\": \"bar\"\n"
-          + //
-          "                    }\n"
-          + //
-          "                }\n"
-          + //
-          "            ]\n"
-          + //
-          "        },\n"
-          + //
-          "        {\n"
-          + //
-          "            \"name\": \"featureZ\",\n"
-          + //
-          "            \"enabled\": true,\n"
-          + //
-          "            \"strategies\": [\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"default\"\n"
-          + //
-          "                },\n"
-          + //
-          "                {\n"
-          + //
-          "                    \"name\": \"hola\",\n"
-          + //
-          "                    \"parameters\": {\n"
-          + //
-          "                        \"name\": \"val\"\n"
-          + //
-          "                    },\n"
-          + //
-          "                    \"segments\": [\n"
-          + //
-          "                        1\n"
-          + //
-          "                    ]\n"
-          + //
-          "                }\n"
-          + //
-          "            ]\n"
-          + //
-          "        }\n"
-          + //
-          "    ]\n"
-          + //
-          "}\n"
-          + //
-          "";
-
   // Assume this is set up to be your feature JSON
   private final String simpleFeatures =
       loadFeaturesFromFile("../client-specification/specifications/01-simple-examples.json");
@@ -403,7 +208,7 @@ class UnleashEngineTest {
   }
 
   @Test
-  void testMetrics() throws YggdrasilError, YggdrasilInvalidInputException {
+  void testMetrics() throws YggdrasilInvalidInputException {
     String features = "{\"version\":1,\"features\":[" +
             "{\"name\":\"Feature.Variants.A\",\"enabled\":true,\"strategies\":[],\"variants\":[{\"name\":\"variant1\",\"weight\":1}]}," +
             "{\"name\":\"Feature.Variants.B\",\"enabled\":true,\"strategies\":[{\"name\":\"userWithId\",\"parameters\":{\"userIds\":\"123\"}}],\"variants\":[]}" +
@@ -415,7 +220,6 @@ class UnleashEngineTest {
     engine.getVariant("Missing.but.checked", new Context());
     engine.getVariant("Missing.but.checked", new Context());
 
-    // engine.countToggle("Feature.C", false);
     MetricsBucket bucket = engine.getMetrics();
 
     assertNotNull(bucket);
@@ -424,7 +228,7 @@ class UnleashEngineTest {
     Instant stop = bucket.getStop();
     assertNotNull(start);
     assertNotNull(stop);
-    assertTrue(!stop.isBefore(start)); // being equal is fine, being before signals some corruption
+    assertFalse(stop.isBefore(start)); // being equal is fine, being before signals some corruption
     assertTrue(start.until(Instant.now(), ChronoUnit.SECONDS) < 10); // should be within 10
     // seconds of now
 

--- a/pure-wasm/src/lib.rs
+++ b/pure-wasm/src/lib.rs
@@ -237,7 +237,7 @@ pub extern "C" fn check_variant(engine_ptr: i32, message_ptr: i32, message_len: 
         let variant = engine.check_variant(&context);
         let enabled = engine.check_enabled(&context).unwrap_or_default();
 
-        engine.count_toggle(&context.toggle_name, variant.is_some());
+        engine.count_toggle(&context.toggle_name, enabled);
 
         if let Some(variant) = &variant {
             engine.count_variant(&context.toggle_name, &variant.name);


### PR DESCRIPTION
Hi! After updating to the WASM-based Unleash Java Client 11.0.0 I've noticed a strange behaviour - all the exposure metrics collected via `getVariant` (and, by extension, `evaluateAllToggles`) were counted as a "yes" - even when the strategies resolved the toggle to not exposed. I think I got the bug - I've tweaked the `testMetrics()` case slightly to expose this case.

## About the changes
The changes contain:
- modified test scenario to replicate my case
- one-liner fix in the `pure_wasm` module
- some code cleanup in `UnleashEngineTest.java`
