### PR TITLE
chore(dotnet): rename bundled assemblies to contain version

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -52,9 +52,16 @@ internal static class NativeLibLoader
         if (os == "linux" && IsMusl())
             libc = "-musl";
 
+        var versionAttribute = Assembly
+            .GetExecutingAssembly()
+            .GetCustomAttribute<YggdrasilCoreVersionAttribute>();
+        if (versionAttribute == null)
+            throw new InvalidOperationException("YggdrasilCoreVersionAttribute was not defined on the assembly.");
+        var versionString = versionAttribute.Version;
+
         string filename = os == "win"
-            ? $"yggdrasilffi_{arch}.dll"
-            : $"libyggdrasilffi_{arch}{libc}.{(os == "osx" ? "dylib" : "so")}";
+            ? $"yggdrasilffi_{arch}_{versionString}.dll"
+            : $"libyggdrasilffi_{arch}{libc}_{versionString}.{(os == "osx" ? "dylib" : "so")}";
 
         return filename;
     }

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -22,6 +22,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="YggdrasilCoreVersion">
+        <_Parameter1>$(YggdrasilCoreVersion)</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
@@ -38,25 +44,43 @@
 
   <ItemGroup>
     <EmbeddedResource Include="../../target/release/libyggdrasilffi.so" Condition="Exists('../../target/release/libyggdrasilffi.so')">
-      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64.so</LogicalName>
+      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64_$(YggdrasilCoreVersion).so</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="../../target/release/yggdrasilffi.dll" Condition="Exists('../../target/release/yggdrasilffi.dll')">
-      <LogicalName>Yggdrasil.Engine.yggdrasilffi_x86_64.dll</LogicalName>
+      <LogicalName>Yggdrasil.Engine.yggdrasilffi_x86_64_$(YggdrasilCoreVersion).dll</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="../../target/release/libyggdrasilffi.dylib" Condition="Exists('../../target/release/libyggdrasilffi.dylib')">
-      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64.dylib</LogicalName>
+      <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64_$(YggdrasilCoreVersion).dylib</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="../runtimes/win-x64/native/yggdrasilffi_x86_64.dll" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi_x86_64.dll')" />
-    <EmbeddedResource Include="../runtimes/win-arm64/native/yggdrasilffi_arm64.dll" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi_arm64.dll')" />
-    <EmbeddedResource Include="../runtimes/win-x86/native/yggdrasilffi_i686.dll" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi_i686.dll')" />
-    <EmbeddedResource Include="../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so" Condition="Exists('../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so')" />
-    <EmbeddedResource Include="../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so" Condition="Exists('../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so')" />
-    <EmbeddedResource Include="../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so" Condition="Exists('../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so')" />
-    <EmbeddedResource Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so')" />
-    <EmbeddedResource Include="../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib')" />
-    <EmbeddedResource Include="../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib')" />
+    <EmbeddedResource Include="../runtimes/win-x64/native/yggdrasilffi_x86_64.dll" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi_x86_64.dll')">
+      <LogicalName>yggdrasilffi_x86_64_$(YggdrasilCoreVersion).dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/win-arm64/native/yggdrasilffi_arm64.dll" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi_arm64.dll')">
+      <LogicalName>yggdrasilffi_arm64_$(YggdrasilCoreVersion).dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/win-x86/native/yggdrasilffi_i686.dll" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi_i686.dll')">
+      <LogicalName>yggdrasilffi_i686_$(YggdrasilCoreVersion).dll</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so" Condition="Exists('../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so')">
+      <LogicalName>libyggdrasilffi_x86_64_$(YggdrasilCoreVersion).so</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so" Condition="Exists('../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so')">
+      <LogicalName>libyggdrasilffi_arm64_$(YggdrasilCoreVersion).so</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so" Condition="Exists('../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so')">
+      <LogicalName>libyggdrasilffi_x86_64-musl_$(YggdrasilCoreVersion).so</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so')">
+      <LogicalName>libyggdrasilffi_arm64-musl_$(YggdrasilCoreVersion).so</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib')">
+      <LogicalName>libyggdrasilffi_x86_64_$(YggdrasilCoreVersion).dylib</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib')">
+      <LogicalName>libyggdrasilffi_arm64_$(YggdrasilCoreVersion).dylib</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilCoreVersionAttribute.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilCoreVersionAttribute.cs
@@ -1,0 +1,10 @@
+[AttributeUsage(AttributeTargets.Assembly)]
+public class YggdrasilCoreVersionAttribute : System.Attribute
+{
+    public string Version { get; }
+
+    public YggdrasilCoreVersionAttribute(string version)
+    {
+        Version = version;
+    }
+}


### PR DESCRIPTION
This includes version metadata into the assembly which is then used to name assemblies to improve deployment/update scenarios