### PR TITLE
chore(dotnet): bump engine version to 1.0.8-beta.0

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.0.7</Version>
+    <Version>1.0.8-beta.0</Version>
     <YggdrasilCoreVersion>0.17.5</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>


### PR DESCRIPTION
bumps the version of Yggdrasil.Engine .NET to 1.0.8-beta.0 so we can test .NET6 target, and how this all works on windows + .NET 4.7.2+