### PR TITLE
chore: ability to run publish_jars from previous branch

### DIFF
--- a/.github/workflows/publish-java.yaml
+++ b/.github/workflows/publish-java.yaml
@@ -1,0 +1,11 @@
+name: Publish Java
+on:
+  workflow_dispatch:
+
+jobs:
+
+  publish_jars:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo "No op, just to be able to trigger from branch"


### PR DESCRIPTION
This will allow us to run the action from a branch to release a patched version of java-engine