### PR TITLE
fix: avoid panic when scalar-operator constraint has null value

### DIFF
--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -333,21 +333,25 @@ fn upgrade_constraint(constraint: &Constraint) -> String {
             escape_quotes(constraint.value.as_ref().unwrap_or(&"".to_string()))
         )
     } else {
-        if constraint.operator == Operator::SemverEq
-            || constraint.operator == Operator::SemverLt
-            || constraint.operator == Operator::SemverGt
-            || constraint.operator == Operator::SemverLte
-            || constraint.operator == Operator::SemverGte
+        let Some(value) = constraint.value.as_ref() else {
+            return "false".into();
+        };
+        if matches!(
+            constraint.operator,
+            Operator::SemverEq
+                | Operator::SemverLt
+                | Operator::SemverGt
+                | Operator::SemverLte
+                | Operator::SemverGte
+        ) && value.starts_with('v')
         {
             // A silly special case where we want to ingest
             // broken semver operators so we can reject them.
             // Handling this in the grammar feels awful so we're
             // just not going to
-            if constraint.value.as_ref().unwrap().starts_with('v') {
-                return "false".into();
-            }
+            return "false".into();
         }
-        constraint.value.clone().unwrap()
+        value.clone()
     };
 
     format!("{inversion}{context_name} {op} {value}")
@@ -796,6 +800,45 @@ mod tests {
         };
         let rule = upgrade_constraint(&constraint);
         assert_eq!(rule.as_str(), expected);
+    }
+
+    #[test_case(Operator::NumEq)]
+    #[test_case(Operator::NumLt)]
+    #[test_case(Operator::NumLte)]
+    #[test_case(Operator::NumGt)]
+    #[test_case(Operator::NumGte)]
+    #[test_case(Operator::DateAfter)]
+    #[test_case(Operator::DateBefore)]
+    #[test_case(Operator::SemverEq)]
+    #[test_case(Operator::SemverLt)]
+    #[test_case(Operator::SemverGt)]
+    #[test_case(Operator::SemverLte)]
+    #[test_case(Operator::SemverGte)]
+    fn scalar_operator_with_null_value_is_never_match(op: Operator) {
+        let constraint = Constraint {
+            context_name: "userId".into(),
+            operator: op,
+            case_insensitive: false,
+            inverted: false,
+            values: None,
+            value: None,
+        };
+        let rule = upgrade_constraint(&constraint);
+        assert_eq!(rule.as_str(), "false");
+    }
+
+    #[test]
+    fn scalar_operator_with_value_in_values_field_is_never_match() {
+        let constraint = Constraint {
+            context_name: "createdAt".into(),
+            operator: Operator::DateAfter,
+            case_insensitive: false,
+            inverted: false,
+            values: Some(vec!["2024-01-01T00:00:00Z".into()]),
+            value: None,
+        };
+        let rule = upgrade_constraint(&constraint);
+        assert_eq!(rule.as_str(), "false");
     }
 
     #[test_case(true, "!user_id <= 7")]


### PR DESCRIPTION
## Bug

`upgrade_constraint` in `strategy_upgrade.rs` unwraps `constraint.value` unconditionally in the scalar-operator branch (`NUM_*`, `DATE_*`, `SEMVER_*`). When `value` is `null` the unwrap panics. Because the panic happens inside the FFI boundary used by the language bindings (PyO3, .NET, JNI), it cannot unwind — `nounwind` aborts the entire host process, killing the worker that triggered the refresh.

## Example

Any client receiving this from `/client/features` panics on its next refresh:

```json
{
  "contextName": "createdAt",
  "operator": "DATE_AFTER",
  "value": null,
  "values": ["2024-01-01T00:00:00Z"]
}
```

One realistic way to produce this: edit the constraint in the Unleash admin UI and save a scalar into the `values[]` array instead of the `value` scalar field. The server happily stores it; the engine then aborts on the consumer side.

## Fix

Replace the unconditional `unwrap()` with a `let-else` that returns `"false"` (never-match) when `value` is `None`. This matches the existing convention in the same branch — the SemVer-with-`v`-prefix special case already returns `"false"` for broken inputs. A constraint with a missing value silently never matches instead of aborting the process.

The same guard now covers both unwrap sites in this branch (the SemVer `starts_with('v')` check and the final clone).

## Tests

Added two tests in `mod tests`:

- `scalar_operator_with_null_value_is_never_match` — parametrized over all 12 scalar operators (`NumEq`/`Lt`/`Lte`/`Gt`/`Gte`, `DateAfter`/`Before`, `SemverEq`/`Lt`/`Lte`/`Gt`/`Gte`). Each builds a constraint with `value: None` and asserts `upgrade_constraint` returns `"false"`.
- `scalar_operator_with_value_in_values_field_is_never_match` — the realistic case where the scalar landed in `values[]` instead of `value`.

Without the fix every parametrized case panics; with the fix all 13 pass. Existing tests are unaffected.