### PR TITLE
fix: strategy variants squared the rollout percentage under random stickiness

### DIFF
--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -58,16 +58,12 @@ pub fn build_variant_rules(
     segment_map: &HashMap<i32, Segment>,
     toggle_name: &str,
 ) -> Vec<(String, Vec<StrategyVariant>, String, String)> {
-    let mut custom_strat_count = 0;
     strategies
         .iter()
         .filter(|strategy| strategy.variants.is_some())
         .map(|strategy| {
-            if strategy.is_custom() {
-                custom_strat_count += 1;
-            }
             (
-                upgrade_strategy(strategy, segment_map, custom_strat_count),
+                upgrade_variant_strategy(strategy, segment_map),
                 strategy.variants.clone().unwrap(),
                 strategy
                     .parameters
@@ -132,7 +128,18 @@ fn upgrade_strategy(
         StrategyType::Custom(_) => format!("external_value[\"customStrategy{strategy_count}\"]"),
     };
 
-    let segments = strategy
+    match resolve_strategy_constraints(strategy, segment_map) {
+        Err(_) => "false".into(),
+        Ok(Some(constraints)) => format!("({strategy_rule} and ({constraints}))"),
+        Ok(None) => strategy_rule,
+    }
+}
+
+fn resolve_strategy_constraints(
+    strategy: &Strategy,
+    segment_map: &HashMap<i32, Segment>,
+) -> Result<Option<String>, SdkError> {
+    let segment_constraints = strategy
         .segments
         .as_ref()
         .map(|segment| {
@@ -144,23 +151,20 @@ fn upgrade_strategy(
             })
         })
         .map(|iter| iter.collect::<Result<Vec<Vec<Constraint>>, SdkError>>())
-        .unwrap_or(Ok(vec![]));
-
-    if segments.is_err() {
-        return "false".into(); // We have a broken segment so default the entire strategy to false
-    }
-
-    let mut segment_constraints: Vec<Constraint> =
-        segments.unwrap().into_iter().flatten().collect();
+        .unwrap_or(Ok(vec![]))?;
 
     let mut raw_constraints = vec![];
     raw_constraints.append(&mut strategy.constraints.clone().unwrap_or_default());
-    raw_constraints.append(&mut segment_constraints);
+    raw_constraints.extend(segment_constraints.into_iter().flatten());
 
-    let constraints = upgrade_constraints(raw_constraints);
-    match constraints {
-        Some(constraints) => format!("({strategy_rule} and ({constraints}))"),
-        None => strategy_rule,
+    Ok(upgrade_constraints(raw_constraints))
+}
+
+fn upgrade_variant_strategy(strategy: &Strategy, segment_map: &HashMap<i32, Segment>) -> String {
+    match resolve_strategy_constraints(strategy, segment_map) {
+        Err(_) => "false".into(),
+        Ok(Some(constraints)) => format!("({constraints})"),
+        Ok(None) => "true".into(),
     }
 }
 
@@ -730,6 +734,62 @@ mod tests {
             output.as_str(),
             format!("55% sticky on random[10000] with group_id of \"Feature.flexibleRollout.userId.55\"")
         );
+    }
+
+    #[test]
+    fn variant_selection_rule_omits_rollout_gate() {
+        let mut parameters = HashMap::new();
+        parameters.insert("rollout".into(), "20".into());
+        parameters.insert("stickiness".into(), "random".into());
+        parameters.insert("groupId".into(), "my_experiment".into());
+
+        let strategy = Strategy {
+            name: "flexibleRollout".into(),
+            parameters: Some(parameters),
+            constraints: None,
+            segments: None,
+            sort_order: Some(1),
+            variants: Some(vec![]),
+        };
+
+        let rules = build_variant_rules(&[strategy], &HashMap::new(), "my_toggle");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].0, "true");
+        assert!(
+            !rules[0].0.contains('%'),
+            "variant rule must not carry a rollout gate"
+        );
+    }
+
+    #[test]
+    fn variant_selection_rule_keeps_constraints_but_not_rollout() {
+        let mut parameters = HashMap::new();
+        parameters.insert("rollout".into(), "20".into());
+        parameters.insert("stickiness".into(), "random".into());
+
+        let constraint = Constraint {
+            context_name: "country".into(),
+            values: Some(vec!["norway".into()]),
+            value: None,
+            operator: Operator::In,
+            case_insensitive: false,
+            inverted: false,
+        };
+
+        let strategy = Strategy {
+            name: "flexibleRollout".into(),
+            parameters: Some(parameters),
+            constraints: Some(vec![constraint]),
+            segments: None,
+            sort_order: Some(1),
+            variants: Some(vec![]),
+        };
+
+        let rules = build_variant_rules(&[strategy], &HashMap::new(), "my_toggle");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].0, "(context[\"country\"] in [\"norway\"])");
+        assert!(!rules[0].0.contains('%'));
+        assert!(compile_rule(&rules[0].0).is_ok());
     }
 
     #[test_case(


### PR DESCRIPTION
## About the changes

When a `flexibleRollout` strategy has **strategy variants** and uses `stickiness: "random"`, `get_variant` serves the variant payload to only **rollout²** of traffic instead of `rollout` — a 20% rollout reaches ~4%, 10% → ~1%, 50% → ~25%. It is invisible at `rollout: 100` (100² = 100) and correct under deterministic stickiness, which is likely why it has gone unnoticed. Boolean evaluation (`is_enabled`) is unaffected; only the `get_variant` path.

## Root cause

`get_variant` evaluates the strategy's rollout gate **twice**: first `EngineState::enabled` evaluates the toggle's combined `compiled_strategy`, then — only if enabled — `check_variant_by_toggle` evaluates each variant-bearing strategy's own rule (`compiled_variant_strategy`) to choose whose variants to use. Both rules are produced by the same `upgrade_strategy`, so each embeds the rollout predicate (e.g. `20% sticky on random[10000] …`). Under `random` stickiness the seed is a fresh `rand::rng()` per evaluation, so the two evaluations are independent `Bernoulli(rollout)` events and multiply: `P = (rollout/100)²`. (The reference Node SDK avoids this by evaluating each strategy once and reusing the matched strategy's variant.)

## The fix

Build the variant-**selection** rule from the strategy's constraints/segments only, dropping the activation/rollout gate (`build_variant_rules` → new `upgrade_variant_strategy`). The enabled check has already applied the rollout; variant selection only needs to identify *which* strategy is relevant to the context, which its constraints/segments fully determine. The constraint/segment assembly is factored out of `upgrade_strategy` into a shared `resolve_strategy_constraints`. Net: variant exposure = `rollout × variant weight`, matching the documented model.

## Behaviour / correctness

- `random` + fractional rollout (single strategy): now exact (20% → 20%).
- Deterministic stickiness, `rollout: 100`, feature-level variants: unchanged (already correct).
- Multiple variant-bearing strategies distinguished by constraints/segments: the right strategy is still selected by its constraints.
- Edge case worth a maintainer eye: when two *variant-bearing* strategies differ only by rollout (identical constraints), selection now takes the first by order once the toggle is enabled, rather than re-rolling each strategy's rollout. I believe this matches the intended "first satisfied strategy provides the variant" semantics, but flagging it.

## Testing

- New unit tests in `strategy_upgrade.rs` asserting the variant-selection rule omits the rollout gate and retains constraints.
- Full `unleash-yggdrasil --all-features` suite green, **including the entire client-specification v6.1.0 conformance set: 266 passed, 0 failed** (notably `strategy_variants`, `variants`, `flexible_rollout_strategy`, `multiple_strategies`). `clippy` and `fmt --check` are clean.

## Reproduction

```python
# pip install yggdrasil-engine
import datetime
import json

from yggdrasil_engine.engine import UnleashEngine

ROLLOUT, N = 20, 100_000
state = {
    "version": 2,
    "features": [
        {
            "name": "demo",
            "type": "experiment",
            "enabled": True,
            "project": "default",
            "strategies": [
                {
                    "name": "flexibleRollout",
                    "parameters": {
                        "rollout": str(ROLLOUT),
                        "stickiness": "random",
                        "groupId": "demo",
                    },
                    "variants": [
                        {
                            "name": "treatment",
                            "weight": 1000,
                            "weightType": "variable",
                            "stickiness": "random",
                            "payload": {"type": "string", "value": "on"},
                        }
                    ],
                }
            ],
            "variants": [],
        }
    ],
}

engine = UnleashEngine()
engine.take_state(json.dumps(state))

enabled = variant = 0
for i in range(N):
    ctx = {"userId": str(i), "currentTime": datetime.datetime(2026, 1, 1).isoformat()}
    enabled += bool(engine.is_enabled("demo", ctx))
    v = engine.get_variant("demo", ctx)
    variant += bool(v and v.enabled)

print(f"is_enabled         = {100 * enabled / N:.2f}%   (expected ~{ROLLOUT}%)")
print(f"get_variant served = {100 * variant / N:.2f}%   (expected ~{ROLLOUT}%; bug = rollout^2 = {ROLLOUT ** 2 // 100}%)")
```

On a current release this prints roughly:

```
is_enabled         = 19.52%   (expected ~20%)
get_variant served = 3.83%   (expected ~20%; bug = rollout^2 = 4%)
```

With this fix, `get_variant served` becomes ~20%.
