### PR TITLE
refactor: rework rule upgrade code so that we can avoid panics and

### DIFF
--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -186,7 +186,7 @@ pub fn compile(
     segment_map: &HashMap<i32, Segment>,
     warnings: &mut Vec<EvalWarning>,
 ) -> CompiledToggle {
-    let enabled_lambda = (|| {
+    let enabled_rule = (|| {
         let strategies = toggle.strategies.clone().unwrap_or_default();
         let rule_text = upgrade(&strategies, segment_map)?;
         compile_rule(rule_text.as_str())
@@ -200,7 +200,7 @@ pub fn compile(
         Box::new(|_| false)
     });
 
-    let get_variant_lambda = compile_variant_rule(toggle, segment_map).unwrap_or_else(|e| {
+    let get_variant_rule = compile_variant_rule(toggle, segment_map).unwrap_or_else(|e| {
         warnings.push(EvalWarning {
             toggle_name: toggle.name.clone(),
             message: format!("Failed to compile toggle, this will always be off {e:?}"),
@@ -213,9 +213,9 @@ pub fn compile(
         name: toggle.name.clone(),
         enabled: toggle.enabled,
         feature_type: toggle.feature_type.clone(),
-        compiled_variant_strategy: get_variant_lambda,
+        compiled_variant_strategy: get_variant_rule,
         variants: compile_variants(&toggle.variants),
-        compiled_strategy: enabled_lambda,
+        compiled_strategy: enabled_rule,
         impression_data: toggle.impression_data.unwrap_or_default(),
         project: toggle.project.clone().unwrap_or("default".to_string()),
         dependencies: toggle.dependencies.clone().unwrap_or_default(),

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -203,7 +203,7 @@ pub fn compile(
     let get_variant_rule = compile_variant_rule(toggle, segment_map).unwrap_or_else(|e| {
         warnings.push(EvalWarning {
             toggle_name: toggle.name.clone(),
-            message: format!("Failed to compile toggle, this will always be off {e:?}"),
+            message: format!("Failed to compile toggle, this will always resolve to the default variant {e:?}"),
         });
 
         None

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -203,7 +203,9 @@ pub fn compile(
     let get_variant_rule = compile_variant_rule(toggle, segment_map).unwrap_or_else(|e| {
         warnings.push(EvalWarning {
             toggle_name: toggle.name.clone(),
-            message: format!("Failed to compile toggle, this will always resolve to the default variant {e:?}"),
+            message: format!(
+                "Failed to compile toggle, this will always resolve to the default variant {e:?}"
+            ),
         });
 
         None

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -33,6 +33,8 @@ use unleash_types::client_features::{
 };
 use unleash_types::client_metrics::{MetricBucket, ToggleStats};
 
+use crate::state::SdkError;
+
 pub type CompiledState = AHashMap<String, CompiledToggle>;
 
 pub const SUPPORTED_SPEC_VERSION: &str = "6.1.0";
@@ -124,13 +126,13 @@ fn build_segment_map(segments: &Option<Vec<Segment>>) -> HashMap<i32, Segment> {
 fn compile_variant_rule(
     toggle: &ClientFeature,
     segment_map: &HashMap<i32, Segment>,
-) -> Option<Vec<(RuleFragment, Vec<CompiledVariant>, String)>> {
+) -> Result<Option<Vec<(RuleFragment, Vec<CompiledVariant>, String)>>, SdkError> {
     let variant_rules: Option<Vec<(RuleFragment, Vec<CompiledVariant>, String)>> =
         build_variant_rules(
             &toggle.strategies.clone().unwrap_or_default(),
             segment_map,
             &toggle.name,
-        )
+        )?
         .iter()
         .map(|(rule_string, strategy_variants, stickiness, group_id)| {
             let compiled_rule: Option<RuleFragment> = compile_rule(rule_string).ok();
@@ -153,7 +155,7 @@ fn compile_variant_rule(
         })
         .collect();
 
-    variant_rules
+    Ok(variant_rules)
 }
 
 #[derive(Debug, Serialize)]
@@ -184,22 +186,36 @@ pub fn compile(
     segment_map: &HashMap<i32, Segment>,
     warnings: &mut Vec<EvalWarning>,
 ) -> CompiledToggle {
-    let rule = upgrade(&toggle.strategies.clone().unwrap_or_default(), segment_map);
-    let variant_rule = compile_variant_rule(toggle, segment_map);
+    let enabled_lambda = (|| {
+        let strategies = toggle.strategies.clone().unwrap_or_default();
+        let rule_text = upgrade(&strategies, segment_map)?;
+        compile_rule(rule_text.as_str())
+    })()
+    .unwrap_or_else(|e| {
+        warnings.push(EvalWarning {
+            toggle_name: toggle.name.clone(),
+            message: format!("Failed to compile toggle, this will always be off {e:?}"),
+        });
+
+        Box::new(|_| false)
+    });
+
+    let get_variant_lambda = compile_variant_rule(toggle, segment_map).unwrap_or_else(|e| {
+        warnings.push(EvalWarning {
+            toggle_name: toggle.name.clone(),
+            message: format!("Failed to compile toggle, this will always be off {e:?}"),
+        });
+
+        None
+    });
+
     CompiledToggle {
         name: toggle.name.clone(),
         enabled: toggle.enabled,
         feature_type: toggle.feature_type.clone(),
-        compiled_variant_strategy: variant_rule,
+        compiled_variant_strategy: get_variant_lambda,
         variants: compile_variants(&toggle.variants),
-        compiled_strategy: compile_rule(rule.as_str()).unwrap_or_else(|e| {
-            warnings.push(EvalWarning {
-                toggle_name: toggle.name.clone(),
-                message: format!("Failed to compile toggle, this will always be off {e:?}"),
-            });
-            Box::new(|_| false)
-        }),
-
+        compiled_strategy: enabled_lambda,
         impression_data: toggle.impression_data.unwrap_or_default(),
         project: toggle.project.clone().unwrap_or("default".to_string()),
         dependencies: toggle.dependencies.clone().unwrap_or_default(),
@@ -959,9 +975,7 @@ mod test {
     fn run_client_spec(spec_name: &str) {
         let spec = load_spec(spec_name);
         let mut engine = EngineState::default();
-        let warnings = engine.take_state(spec.state);
-
-        assert!(warnings.is_none());
+        engine.take_state(spec.state);
 
         if let Some(mut tests) = spec.tests {
             while let Some(test_case) = tests.pop() {

--- a/unleash-yggdrasil/src/lib.rs
+++ b/unleash-yggdrasil/src/lib.rs
@@ -40,6 +40,7 @@ pub type CompiledState = AHashMap<String, CompiledToggle>;
 pub const SUPPORTED_SPEC_VERSION: &str = "6.1.0";
 const VARIANT_NORMALIZATION_SEED: u32 = 86028157;
 pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
+type VariantRuleSet = Vec<(RuleFragment, Vec<CompiledVariant>, String)>;
 
 pub const KNOWN_STRATEGIES: [&str; 8] = [
     "default",
@@ -126,34 +127,33 @@ fn build_segment_map(segments: &Option<Vec<Segment>>) -> HashMap<i32, Segment> {
 fn compile_variant_rule(
     toggle: &ClientFeature,
     segment_map: &HashMap<i32, Segment>,
-) -> Result<Option<Vec<(RuleFragment, Vec<CompiledVariant>, String)>>, SdkError> {
-    let variant_rules: Option<Vec<(RuleFragment, Vec<CompiledVariant>, String)>> =
-        build_variant_rules(
-            &toggle.strategies.clone().unwrap_or_default(),
-            segment_map,
-            &toggle.name,
-        )?
-        .iter()
-        .map(|(rule_string, strategy_variants, stickiness, group_id)| {
-            let compiled_rule: Option<RuleFragment> = compile_rule(rule_string).ok();
-            compiled_rule.map(|rule| {
-                (
-                    rule,
-                    strategy_variants
-                        .iter()
-                        .map(|strategy_variant| CompiledVariant {
-                            name: strategy_variant.name.clone(),
-                            weight: strategy_variant.weight,
-                            stickiness: Some(stickiness.clone()),
-                            payload: strategy_variant.payload.clone(),
-                            overrides: None,
-                        })
-                        .collect(),
-                    group_id.clone(),
-                )
-            })
+) -> Result<Option<VariantRuleSet>, SdkError> {
+    let variant_rules: Option<VariantRuleSet> = build_variant_rules(
+        &toggle.strategies.clone().unwrap_or_default(),
+        segment_map,
+        &toggle.name,
+    )?
+    .iter()
+    .map(|(rule_string, strategy_variants, stickiness, group_id)| {
+        let compiled_rule: Option<RuleFragment> = compile_rule(rule_string).ok();
+        compiled_rule.map(|rule| {
+            (
+                rule,
+                strategy_variants
+                    .iter()
+                    .map(|strategy_variant| CompiledVariant {
+                        name: strategy_variant.name.clone(),
+                        weight: strategy_variant.weight,
+                        stickiness: Some(stickiness.clone()),
+                        payload: strategy_variant.payload.clone(),
+                        overrides: None,
+                    })
+                    .collect(),
+                group_id.clone(),
+            )
         })
-        .collect();
+    })
+    .collect();
 
     Ok(variant_rules)
 }

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -35,9 +35,12 @@ impl IsCustom for Strategy {
     }
 }
 
-pub fn upgrade(strategies: &[Strategy], segment_map: &HashMap<i32, Segment>) -> String {
+pub fn upgrade(
+    strategies: &[Strategy],
+    segment_map: &HashMap<i32, Segment>,
+) -> Result<String, SdkError> {
     if strategies.is_empty() {
-        return "true".into();
+        return Ok("true".into());
     }
     let mut custom_strat_count = 0;
     let rule_text = strategies
@@ -48,17 +51,18 @@ pub fn upgrade(strategies: &[Strategy], segment_map: &HashMap<i32, Segment>) -> 
             }
             upgrade_strategy(strategy, segment_map, custom_strat_count)
         })
-        .collect::<Vec<String>>()
+        .collect::<Result<Vec<String>, SdkError>>()?
         .join(" or ");
-    rule_text
+    Ok(rule_text)
 }
 
 pub fn build_variant_rules(
     strategies: &[Strategy],
     segment_map: &HashMap<i32, Segment>,
     toggle_name: &str,
-) -> Vec<(String, Vec<StrategyVariant>, String, String)> {
+) -> Result<Vec<(String, Vec<StrategyVariant>, String, String)>, SdkError> {
     let mut custom_strat_count = 0;
+
     strategies
         .iter()
         .filter(|strategy| strategy.variants.is_some())
@@ -66,8 +70,9 @@ pub fn build_variant_rules(
             if strategy.is_custom() {
                 custom_strat_count += 1;
             }
-            (
-                upgrade_strategy(strategy, segment_map, custom_strat_count),
+
+            Ok((
+                upgrade_strategy(strategy, segment_map, custom_strat_count)?,
                 strategy.variants.clone().unwrap(),
                 strategy
                     .parameters
@@ -81,9 +86,9 @@ pub fn build_variant_rules(
                     .and_then(|params| params.get("groupId"))
                     .cloned()
                     .unwrap_or_else(|| toggle_name.to_owned()),
-            )
+            ))
         })
-        .collect::<Vec<(String, Vec<StrategyVariant>, String, String)>>()
+        .collect()
 }
 
 trait PropResolver {
@@ -119,7 +124,7 @@ fn upgrade_strategy(
     strategy: &Strategy,
     segment_map: &HashMap<i32, Segment>,
     strategy_count: usize,
-) -> String {
+) -> Result<String, SdkError> {
     let strategy_rule = match StrategyType::from(strategy.name.as_str()) {
         StrategyType::Default => "true".into(),
         StrategyType::UserWithId => upgrade_user_id_strategy(strategy),
@@ -140,27 +145,24 @@ fn upgrade_strategy(
                 segment_map
                     .get(segment_id)
                     .map(|segment| segment.constraints.clone())
-                    .ok_or(SdkError::StrategyEvaluationError)
+                    .ok_or(SdkError::StrategyParseError(
+                        "Unable to resolve a segment definition to a segment value".into(),
+                    ))
             })
         })
         .map(|iter| iter.collect::<Result<Vec<Vec<Constraint>>, SdkError>>())
-        .unwrap_or(Ok(vec![]));
+        .unwrap_or(Ok(vec![]))?;
 
-    if segments.is_err() {
-        return "false".into(); // We have a broken segment so default the entire strategy to false
-    }
-
-    let mut segment_constraints: Vec<Constraint> =
-        segments.unwrap().into_iter().flatten().collect();
+    let mut segment_constraints: Vec<Constraint> = segments.into_iter().flatten().collect();
 
     let mut raw_constraints = vec![];
     raw_constraints.append(&mut strategy.constraints.clone().unwrap_or_default());
     raw_constraints.append(&mut segment_constraints);
 
-    let constraints = upgrade_constraints(raw_constraints);
+    let constraints = upgrade_constraints(raw_constraints)?;
     match constraints {
-        Some(constraints) => format!("({strategy_rule} and ({constraints}))"),
-        None => strategy_rule,
+        Some(constraints) => Ok(format!("({strategy_rule} and ({constraints}))")),
+        None => Ok(strategy_rule),
     }
 }
 
@@ -277,16 +279,16 @@ fn get_rollout_target(strategy: &Strategy, target_property: &str) -> Option<usiz
         .and_then(Result::ok)
 }
 
-fn upgrade_constraints(constraints: Vec<Constraint>) -> Option<String> {
+fn upgrade_constraints(constraints: Vec<Constraint>) -> Result<Option<String>, SdkError> {
     if constraints.is_empty() {
-        return None;
+        return Ok(None);
     };
     let constraint_rules = constraints
         .iter()
         .map(upgrade_constraint)
-        .collect::<Vec<String>>();
+        .collect::<Result<Vec<String>, SdkError>>()?;
     let squashed_rules = constraint_rules.join(" and ");
-    Some(squashed_rules)
+    Ok(Some(squashed_rules))
 }
 
 fn is_stringy(op: &Operator) -> bool {
@@ -305,13 +307,12 @@ fn escape_quotes(stringy_operator: &str) -> String {
     stringy_operator.replace('\"', "\\\"")
 }
 
-fn upgrade_constraint(constraint: &Constraint) -> String {
+fn upgrade_constraint(constraint: &Constraint) -> Result<String, SdkError> {
     let context_name = upgrade_context_name(&constraint.context_name);
-    let op = upgrade_operator(&constraint.operator, constraint.case_insensitive);
-    if op.is_none() {
-        return "false".into();
-    }
-    let op = op.unwrap();
+    let op =
+        upgrade_operator(&constraint.operator, constraint.case_insensitive).ok_or_else(|| {
+            SdkError::StrategyParseError("Failed to resolve constraint operator".into())
+        })?;
     let inversion = if constraint.inverted { "!" } else { "" };
 
     let value = if is_stringy(&constraint.operator) {
@@ -344,13 +345,13 @@ fn upgrade_constraint(constraint: &Constraint) -> String {
             // Handling this in the grammar feels awful so we're
             // just not going to
             if constraint.value.as_ref().unwrap().starts_with('v') {
-                return "false".into();
+                return Ok("false".into());
             }
         }
         constraint.value.clone().unwrap()
     };
 
-    format!("{inversion}{context_name} {op} {value}")
+    Ok(format!("{inversion}{context_name} {op} {value}"))
 }
 
 fn upgrade_operator(op: &Operator, case_insensitive: bool) -> Option<String> {
@@ -448,7 +449,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output, "user_id in [\"123\",\"222\",\"88\"]".to_string())
     }
 
@@ -466,7 +467,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output, "user_id in [\"123\",\"222\",\"88\"]".to_string())
     }
 
@@ -490,7 +491,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output, "(true and (user_id in [\"7\"]))".to_string())
     }
 
@@ -514,7 +515,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output,
             "(true and (user_id in [\"7\"] and user_id in [\"7\"]))".to_string()
@@ -532,8 +533,9 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new());
-        assert_eq!(output, "true or true".to_string())
+        let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new())
+            .expect("Failed to upgrade strategy");
+        assert_eq!(output, "true or true".to_string());
     }
 
     #[test]
@@ -556,13 +558,14 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new());
+        let output = upgrade(&vec![strategy.clone(), strategy], &HashMap::new())
+            .expect("Failed to upgrade strategy");
         assert_eq!(output.as_str(), "(true and (user_id in [\"7\"] and user_id in [\"7\"])) or (true and (user_id in [\"7\"] and user_id in [\"7\"]))")
     }
 
     #[test]
     fn no_strategy_is_always_true() {
-        let output = upgrade(&[], &HashMap::new());
+        let output = upgrade(&[], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output.as_str(), "true")
     }
 
@@ -586,7 +589,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             "(true and (context[\"country\"] in [\"norway\"]))"
@@ -610,7 +613,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             "55% sticky on user_id with group_id of \"Feature.flexibleRollout.userId.55\""
@@ -633,7 +636,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output.as_str(), "55% sticky on user_id");
     }
 
@@ -653,7 +656,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             "55% sticky on user_id | session_id | random[10000] with group_id of \"Feature.flexibleRollout.userId.55\""
@@ -675,7 +678,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             "55% sticky on user_id | session_id | random[10000]"
@@ -699,7 +702,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             format!(
@@ -725,7 +728,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             format!("55% sticky on random[10000] with group_id of \"Feature.flexibleRollout.userId.55\"")
@@ -771,7 +774,7 @@ mod tests {
             values: Some(vec!["some".into(), "thing".into()]),
             value: None,
         };
-        let rule = upgrade_constraint(&constraint);
+        let rule = upgrade_constraint(&constraint).expect("Failed to upgrade constraint");
         assert_eq!(rule.as_str(), expected);
     }
 
@@ -794,7 +797,7 @@ mod tests {
             values: None,
             value: Some("7".into()),
         };
-        let rule = upgrade_constraint(&constraint);
+        let rule = upgrade_constraint(&constraint).expect("Failed to upgrade constraint");
         assert_eq!(rule.as_str(), expected);
     }
 
@@ -809,7 +812,7 @@ mod tests {
             values: None,
             value: Some("7".into()),
         };
-        let rule = upgrade_constraint(&constraint);
+        let rule = upgrade_constraint(&constraint).expect("Failed to upgrade constraint");
         assert_eq!(rule.as_str(), expected);
     }
 
@@ -824,7 +827,8 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[custom_strategy], &HashMap::new());
+        let output =
+            upgrade(&[custom_strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert_eq!(output.as_str(), "external_value[\"customStrategy1\"]")
     }
 
@@ -858,7 +862,8 @@ mod tests {
                 custom_strategy,
             ],
             &HashMap::new(),
-        );
+        )
+        .expect("Failed to upgrade strategy");
         assert_eq!(
             output.as_str(),
             "true or true or external_value[\"customStrategy1\"] or external_value[\"customStrategy2\"] or true or external_value[\"customStrategy3\"]"
@@ -875,7 +880,7 @@ mod tests {
             values: Some(vec!["some\"thing".into()]),
             value: None,
         };
-        let rule = upgrade_constraint(&constraint);
+        let rule = upgrade_constraint(&constraint).expect("Failed to upgrade constraint");
         assert_eq!(rule.as_str(), "user_id contains_any [\"some\\\"thing\"]");
     }
 
@@ -892,7 +897,7 @@ mod tests {
             variants: None,
         };
 
-        let output = upgrade(&[strategy], &HashMap::new());
+        let output = upgrade(&[strategy], &HashMap::new()).expect("Failed to upgrade strategy");
         assert!(compile_rule(&output).is_ok());
         assert_eq!(output.as_str(), "hostname in [\"DOS\", \"pop-os\"]");
     }
@@ -914,7 +919,8 @@ mod tests {
             variants: None,
         };
 
-        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        let rule =
+            upgrade_strategy(&strategy, &HashMap::new(), 0).expect("Failed to upgrade strategy");
         assert_eq!(rule.as_str(), "false");
     }
 
@@ -928,7 +934,8 @@ mod tests {
             sort_order: None,
             variants: None,
         };
-        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        let rule =
+            upgrade_strategy(&strategy, &HashMap::new(), 0).expect("Failed to upgrade strategy");
         assert_eq!(rule.as_str(), "false");
     }
 
@@ -942,7 +949,8 @@ mod tests {
             sort_order: None,
             variants: None,
         };
-        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        let rule =
+            upgrade_strategy(&strategy, &HashMap::new(), 0).expect("Failed to upgrade strategy");
         assert_eq!(rule.as_str(), "false");
     }
 
@@ -960,7 +968,8 @@ mod tests {
             sort_order: None,
             variants: None,
         };
-        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        let rule =
+            upgrade_strategy(&strategy, &HashMap::new(), 0).expect("Failed to upgrade strategy");
         assert_eq!(
             rule.as_str(),
             "remote_address in_cidr [\"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"]"
@@ -982,7 +991,8 @@ mod tests {
             variants: None,
         };
 
-        let rule = upgrade_strategy(&strategy, &HashMap::new(), 0);
+        let rule =
+            upgrade_strategy(&strategy, &HashMap::new(), 0).expect("Failed to upgrade a strategy");
 
         assert!(compile_rule(&rule).is_ok());
 

--- a/unleash-yggdrasil/src/strategy_upgrade.rs
+++ b/unleash-yggdrasil/src/strategy_upgrade.rs
@@ -7,6 +7,8 @@ use crate::state::SdkError;
 const DEFAULT_STICKINESS: &str = "user_id | session_id | random[10000]";
 const DEFAULT_RANDOM: &str = "random[10000]";
 
+pub(crate) type RawVariantRule = Vec<(String, Vec<StrategyVariant>, String, String)>;
+
 enum StrategyType {
     Default,
     UserWithId,
@@ -60,7 +62,7 @@ pub fn build_variant_rules(
     strategies: &[Strategy],
     segment_map: &HashMap<i32, Segment>,
     toggle_name: &str,
-) -> Result<Vec<(String, Vec<StrategyVariant>, String, String)>, SdkError> {
+) -> Result<RawVariantRule, SdkError> {
     let mut custom_strat_count = 0;
 
     strategies


### PR DESCRIPTION
This reworks the rule upgrade+compile path a little so that it can bubble errors instead of panicking if it encounters an error. The error cases here are pretty much all in the "oh god no why" scope of error but a panic doesn't help when this is used over an FFI boundary